### PR TITLE
Create (dummy) conformance test runner executable

### DIFF
--- a/ouroboros-consensus-diffusion/app/conformance-test-runner/Main.hs
+++ b/ouroboros-consensus-diffusion/app/conformance-test-runner/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Hello from the conformance testing of consensus runner executable"

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -317,3 +317,11 @@ test-suite consensus-test
     typed-protocols,
     unstable-diffusion-testlib,
     vector,
+
+executable conformance-test-runner
+  import: common-lib
+  hs-source-dirs: app/conformance-test-runner
+  main-is: Main.hs
+  --other-modules:
+  build-depends:
+    base,


### PR DESCRIPTION
Create a bare-bones executable for the conformance testing of consensus runner.
See https://github.com/tweag/cardano-conformance-testing-of-consensus/blob/main/docs/design.md#design

Closes tweag/cardano-conformance-testing-of-consensus#40
