### PR TITLE
Derive generic PeerSchedule JSON instances

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -272,6 +272,7 @@ test-suite consensus-test
 
   build-depends:
     QuickCheck,
+    aeson,
     base,
     binary,
     bytestring,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -9,6 +10,10 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- Orphan instances for 'Time' were introduced temporarily (no pun intended)
+-- to implement generic 'ToJSON' and 'FromJSON' instances for 'PointSchedule'.
+-- Once implemented by hand, they should be removed.
+{-# OPTIONS_GHC -Worphans #-}
 
 -- | Data types and generators for point schedules.
 --
@@ -61,6 +66,7 @@ import Control.Monad.Class.MonadTime.SI
   , diffTime
   )
 import Control.Monad.ST (ST)
+import Data.Aeson (ToJSON(toEncoding), FromJSON, genericToEncoding, defaultOptions)
 import Data.Bifunctor (first)
 import Data.Functor (($>))
 import Data.List (mapAccumL, partition, scanl')
@@ -68,6 +74,7 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Time (DiffTime)
 import Data.Word (Word64)
+import GHC.Generics
 import Network.TypedProtocol
 import Ouroboros.Consensus.Block.Abstract (withOriginToMaybe)
 import Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -213,6 +220,21 @@ data PointSchedule blk = PointSchedule
   -- If no point in the schedule is larger than 'psMinEndTime',
   -- the simulation will still run until this time is reached.
   }
+  deriving (Generic)
+
+instance ToJSON blk => ToJSON (PointSchedule blk) where
+  toEncoding = genericToEncoding defaultOptions
+
+instance FromJSON blk => FromJSON (PointSchedule blk)
+
+-- | TODO(xavier): Remove orphan instance after writing the 'PointSchedule'
+-- instance above by hand.
+instance ToJSON Time where
+  toEncoding = genericToEncoding defaultOptions
+
+-- | TODO(xavier): Remove orphan instance after writing the 'PointSchedule'
+-- instance above by hand.
+instance FromJSON Time
 
 -- | List of all blocks appearing in the schedules.
 peerSchedulesBlocks :: Peers (PeerSchedule blk) -> [blk]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -39,6 +39,7 @@ module Test.Consensus.PointSchedule.Peers
   , updatePeer
   ) where
 
+import Data.Aeson (ToJSON(toEncoding), FromJSON, genericToEncoding, defaultOptions)
 import Data.Hashable (Hashable)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -78,6 +79,11 @@ instance CondenseList PeerId where
 
 instance Hashable PeerId
 
+instance ToJSON PeerId where
+  toEncoding = genericToEncoding defaultOptions
+
+instance FromJSON PeerId
+
 -- | General-purpose functor associated with a peer.
 data Peer a
   = Peer
@@ -111,7 +117,12 @@ data Peers a = Peers
   { honestPeers :: Map Int a
   , adversarialPeers :: Map Int a
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON a => ToJSON (Peers a) where
+  toEncoding = genericToEncoding defaultOptions
+
+instance FromJSON a => FromJSON (Peers a)
 
 -- | Variant of 'honestPeers' that returns a map with 'PeerId's as keys.
 honestPeers' :: Peers a -> Map PeerId a

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/SinglePeer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -- | This module contains functions for generating random point schedules.
 --
 -- A point schedule is a set of tables, having one table per simulated peer.
@@ -99,10 +100,12 @@ module Test.Consensus.PointSchedule.SinglePeer
 import Cardano.Slotting.Slot (WithOrigin (At, Origin), withOrigin)
 import Control.Arrow (second)
 import Control.Monad.Class.MonadTime.SI (Time)
+import Data.Aeson (ToJSON(toEncoding), FromJSON, genericToEncoding, defaultOptions)
 import Data.List (mapAccumL)
 import Data.Time.Clock (DiffTime)
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
+import GHC.Generics
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import Ouroboros.Network.Block (BlockNo (unBlockNo), blockSlot)
 import qualified System.Random.Stateful as R (StatefulGen)
@@ -118,7 +121,12 @@ data SchedulePoint blk
   = ScheduleTipPoint (WithOrigin blk)
   | ScheduleHeaderPoint (WithOrigin blk)
   | ScheduleBlockPoint (WithOrigin blk)
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance ToJSON blk => ToJSON (SchedulePoint blk) where
+  toEncoding = genericToEncoding defaultOptions
+  
+instance FromJSON blk => FromJSON (SchedulePoint blk)
 
 scheduleTipPoint :: blk -> SchedulePoint blk
 scheduleTipPoint = ScheduleTipPoint . At


### PR DESCRIPTION
This PR introduces generic (and provisional) `ToJSON` and `FromJSON` instances for the serialization of `PointSchedule`s. as a step towards a MVP for our test runner as stated. See the [design document](https://github.com/tweag/cardano-conformance-testing-of-consensus/blob/main/docs/design.md#milestone-1---run-point-schedules-and-property-tests-for-cardano-node).

Unfortunately, orphan instances had to be defined for `Time`; we'll deal away with them once we write the instances by hand.

Closes tweag/cardano-conformance-testing-of-consensus#38
