### PR TITLE
Parse runner CLI arguments

### DIFF
--- a/ouroboros-consensus-diffusion/app/conformance-test-runner/Options.hs
+++ b/ouroboros-consensus-diffusion/app/conformance-test-runner/Options.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | Command line argument parser for the test runner.
+module Options (execParser, options, Options (..), TestFile) where
+
+import Options.Applicative
+import Ouroboros.Network.PeerSelection (PortNumber)
+
+-- | TODO: Place holder for an actual file input.
+-- Remove after the file format and its parser are defined.
+data TestFile = TestFile deriving Read
+
+data Options = Options
+  { optTestFile :: TestFile
+  , optOutputTopologyFile :: String
+  , optPort :: PortNumber
+  }
+
+options :: ParserInfo Options
+options =
+  info
+    (optsP <**> helper)
+    ( mconcat
+        [ fullDesc
+        , progDesc
+            ( mconcat
+                [ "Locally simulate peers described by the TEST_FILE "
+                , "to tests a node's resulting state for consensus"
+                ]
+            )
+        , header "runner - A conformance test runner"
+        ]
+    )
+
+optsP :: Parser Options
+optsP = do
+  optTestFile <- argument auto (metavar "TEST_FILE")
+  optOutputTopologyFile <-
+    strOption
+      ( mconcat
+          [ long "output-topology-file"
+          , short 'o'
+          , metavar "FILE_NAME"
+          , value "topology.json"
+          , help "File path for the testing topology file (JSON)"
+          ]
+      )
+  optPort <-
+    option
+      auto
+      ( mconcat
+          [ long "port"
+          , short 'p'
+          , metavar "PORT_NUMBER"
+          , value 3001
+          , help "Starting port for simulated peers"
+          ]
+      )
+  pure Options{..}

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -333,10 +333,11 @@ executable conformance-test-runner
   import: common-lib
   hs-source-dirs: app/conformance-test-runner
   main-is: Main.hs
-  --other-modules:
+  other-modules: Options
   build-depends:
     base,
     containers,
+    optparse-applicative,
     ouroboros-network:{ouroboros-network, orphan-instances},
     ouroboros-consensus,
     unstable-consensus-conformance-testlib,


### PR DESCRIPTION
# Description

This PR implements a simple parser for the test runner CLI using `optparse-applicative`. It has a single mandatory argument for an input test file, and optional `--output-topology-file` and `--port` flags to specify the name and path of the resulting topology file (defaulting to the current directory to `topology.json`) and the starting port assigned to the simulated peers, respectively.

Stacked on #5
Closes tweag/cardano-conformance-testing-of-consensus#39
