### PR TITLE
Parse a point schedule from input file

### DIFF
--- a/ouroboros-consensus-diffusion/app/conformance-test-runner/Main.hs
+++ b/ouroboros-consensus-diffusion/app/conformance-test-runner/Main.hs
@@ -8,7 +8,6 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Options
   ( Options (..)
-  , TestFile
   , execParser
   , options
   )
@@ -25,11 +24,6 @@ import Ouroboros.Network.PeerSelection.LedgerPeers
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..), WarmValency (..))
 import Test.Consensus.PointSchedule
 import Test.Consensus.PointSchedule.Peers (PeerId (..), Peers (Peers), getPeerIds)
-
--- | TODO: Place holder for the actual file parser.
--- Implement after the file format is defined.
-parseTestFile :: TestFile -> PointSchedule blk
-parseTestFile = const testPointSchedule
 
 testPointSchedule :: PointSchedule blk
 testPointSchedule =
@@ -76,6 +70,7 @@ makeTopology ports =
 main :: IO ()
 main = do
   opts <- execParser options
-  let pointSchedule = parseTestFile (optTestFile opts)
-      simPeerMap = buildPeerMap (optPort opts) pointSchedule
+  contents <- BSL8.readFile (optTestFile opts)
+  pointSchedule <- throwDecode contents :: IO (PointSchedule Bool)
+  let simPeerMap = buildPeerMap (optPort opts) pointSchedule
   BSL8.writeFile (optOutputTopologyFile opts) (encode $ makeTopology simPeerMap)

--- a/ouroboros-consensus-diffusion/app/conformance-test-runner/Options.hs
+++ b/ouroboros-consensus-diffusion/app/conformance-test-runner/Options.hs
@@ -2,17 +2,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Command line argument parser for the test runner.
-module Options (execParser, options, Options (..), TestFile) where
+module Options (execParser, options, Options (..)) where
 
 import Options.Applicative
 import Ouroboros.Network.PeerSelection (PortNumber)
 
--- | TODO: Place holder for an actual file input.
--- Remove after the file format and its parser are defined.
-data TestFile = TestFile deriving Read
-
 data Options = Options
-  { optTestFile :: TestFile
+  { optTestFile :: FilePath
   , optOutputTopologyFile :: String
   , optPort :: PortNumber
   }


### PR DESCRIPTION
# Description

Follow up to #6.

Replaces the place holder `TestFile` type with an actual file path on the
executable argument. Currently, we aim for our test files to contain only
a serialized `PointSchedule`; we parse a `PointSchedule Bool`, as we have yet
to decide our actual block type (probably `Test.Util.TestBlock.Testblock`).
