### PR TITLE
Implement conformace test suite type

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -241,6 +241,7 @@ library unstable-consensus-conformance-testlib
     Test.Consensus.Genesis.Tests.LoP
     Test.Consensus.Genesis.Tests.LongRangeAttack
     Test.Consensus.Genesis.Tests.Uniform
+    Test.Consensus.Genesis.TestSuite
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -291,7 +291,6 @@ library unstable-consensus-conformance-testlib
     containers,
     contra-tracer,
     directory,
-    extra,
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     hashable,

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -297,6 +297,7 @@ library unstable-consensus-conformance-testlib
     io-classes,
     io-sim,
     mempack,
+    monoidal-containers,
     mtl,
     nothunks,
     ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -291,6 +291,7 @@ library unstable-consensus-conformance-testlib
     containers,
     contra-tracer,
     directory,
+    extra,
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     hashable,

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -325,6 +325,7 @@ library unstable-consensus-conformance-testlib
     time,
     tree-diff,
     typed-protocols,
+    universe-base,
     unstable-diffusion-testlib,
     vector,
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -81,10 +81,12 @@ data ConformanceTest blk = ConformanceTest
     -- ^ Adjust the default number of test runs to check the property.
   , ctMaxSize :: Int -> Int
     -- ^ Adjust the default test case maximum size.
+  , ctDescription :: String
   }
 
 mkConformanceTest ::
   (Testable prop) =>
+  String ->
   (Int -> Int) ->
   (Int -> Int) ->
   Gen (GenesisTestFull blk) ->
@@ -92,7 +94,7 @@ mkConformanceTest ::
   (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) ->
   (GenesisTestFull blk -> StateView blk -> prop) ->
   ConformanceTest blk
-mkConformanceTest ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
+mkConformanceTest ctDescription ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
   let ctProperty = fmap property . mkProperty
    in ConformanceTest {..}
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -72,28 +72,29 @@ data ConformanceTest blk = ConformanceTest
   { ctGenerator       :: Gen (GenesisTestFull blk)
     -- ^ The test generator.
   , ctSchedulerConfig :: SchedulerConfig
-    -- ^ Scheduler configuration parameters.
+    -- ^ Peer simulator scheduler configuration.
   , ctShrinker        :: (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk])
     -- ^ A shrinker allowed to inspect the output value of a test.
    , ctProperty        :: GenesisTestFull blk -> StateView blk -> Property
-    -- ^ The property to test.
+    -- ^ The property to check on the test result.
   , ctDesiredPasses   :: Int -> Int
     -- ^ Adjust the default number of test runs to check the property.
   , ctMaxSize :: Int -> Int
     -- ^ Adjust the default test case maximum size.
   , ctDescription :: String
+    -- ^ A description for the test.
   }
 
 mkConformanceTest ::
-  (Testable prop) =>
-  String ->
-  (Int -> Int) ->
-  (Int -> Int) ->
-  Gen (GenesisTestFull blk) ->
-  SchedulerConfig ->
-  (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) ->
-  (GenesisTestFull blk -> StateView blk -> prop) ->
-  ConformanceTest blk
+  (Testable prop)
+  => String  -- ^ Test description.
+  -> (Int -> Int) -- ^ Transformation of the default desired test passes/successes.
+  -> (Int -> Int) -- ^ Transformation of the default max test size.
+  -> Gen (GenesisTestFull blk) -- ^ Test generator.
+  -> SchedulerConfig -- ^ Peer simulator scheduler configuration.
+  -> (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) -- ^ Result inspecting shrinker.
+  -> (GenesisTestFull blk -> StateView blk -> prop) -- ^ Property on test result.
+  -> ConformanceTest blk
 mkConformanceTest ctDescription ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
   let ctProperty = fmap property . mkProperty
    in ConformanceTest {..}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,6 +22,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Universe.Class
 import           Ouroboros.Consensus.Block (BlockSupportsDiffusionPipelining,
                      ConvertRawHash, Header)
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
@@ -45,20 +45,33 @@ import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.TersePrinting (Terse)
 
 data TestSuiteData blk = TestSuiteData
-  { prefix :: NonEmpty Prefix -- ^ The nested groups a test belongs to. The `head` corresponds to the top level.
-  , test   :: ConformanceTest blk -- ^ The test to run
+  { -- | The nested groups a test belongs to.
+    -- It is 'NonEmpty', as we need a test description/name
+    -- in order to produce a 'TestTree'. For this, the
+    -- convention is to use the 'NonEmpty.last' and nest
+    -- the test by appending.
+    prefix :: NonEmpty Prefix
+
+    -- | The test to run.
+  , test   :: ConformanceTest blk
   }
 
 type Prefix = String
 
 newtype TestSuite blk key = TestSuite (Map key (TestSuiteData blk))
-  deriving newtype (Semigroup, Monoid)
 
-mkTestSuite :: Prefix -> key -> ConformanceTest blk -> TestSuite blk key
-mkTestSuite p k t = TestSuite . Map.singleton k $
-  TestSuiteData { prefix = [p]
-                , test = t
-                }
+-- | Smart constructor for a 'TestSuite'.
+mkTestSuite :: (Ord key, Finite key)
+            => (key -> Prefix)
+            -> (key -> ConformanceTest blk)
+            -> TestSuite blk key
+mkTestSuite toDescription toTest = TestSuite . Map.fromList $
+  [ (k, tsData)
+  | k <- universeF
+  , let tsData = TestSuiteData { prefix = [toDescription k]
+                               , test = toTest k
+                               }
+  ]
 
 mapKeys :: Ord b => (a -> b) -> TestSuite blk a -> TestSuite blk b
 mapKeys f (TestSuite m) = TestSuite $ Map.mapKeys f m
@@ -66,7 +79,7 @@ mapKeys f (TestSuite m) = TestSuite $ Map.mapKeys f m
 get :: Ord key => TestSuite blk key -> key ->  ConformanceTest blk
 get (TestSuite m) k = test $ case Map.lookup k m of
   Just t  -> t
-  Nothing -> error "TestSuite.get: Impossible! All test classes have a value."
+  Nothing -> error "TestSuite.get: Impossible! All test classes have a value by contruction."
 
 nest :: [Prefix] -> TestSuite blk key -> TestSuite blk key
 nest pfs (TestSuite m) = TestSuite $
@@ -96,29 +109,31 @@ compileSingleTest ::
   ) =>
   TestSuiteData blk -> ([Prefix], TestTree)
 compileSingleTest (TestSuiteData {prefix, test}) =
-  -- The last element of the prefix corresponds to the individual test
-  -- description/name. So all test matching on `init` are in the same group level.
+  -- The 'last' element of the 'prefix' corresponds to the individual test
+  -- description/name. Conversely, the 'init' corresponds to the enclosing
+  -- test groups.
   let (prefixes,testName) = (NonEmpty.init prefix, NonEmpty.last prefix)
    in (prefixes, QC.testProperty testName (runConformanceTest test))
 
--- | Recursively build test groups by following the hierarchy described by a
--- the 'Prefix' list. The resulting 'TestTrees' are considered to be part
+-- | Recursively build test groups by following the hierarchy described by
+-- the '[Prefix]'. The resulting '[TestTree]' are considered to be part
 -- of the same top level group.
 buildGroups :: [([Prefix], TestTree)] -> [TestTree]
 buildGroups entries =
   let
-    -- Tests that belong directly at this level.
-    (here, deeper) = partition (null . fst) entries
+    -- Distinguish between tests that belong to the top level
+    -- from the nested ones.
+    (toplevel, nested) = partition (null . fst) entries
 
     topLevelTests :: [TestTree]
-    topLevelTests = fmap snd here
+    topLevelTests = fmap snd toplevel
 
-    -- Group the deeper tests by their first prefix
+    -- Group the nested tests by their first prefix.
     grouped :: Map Prefix [([Prefix], TestTree)]
     grouped =
       Map.fromListWith (<>)
         [ (p, [(ps, t)])
-        | (p:ps, t) <- deeper
+        | (p:ps, t) <- nested
         ]
 
     subgroups :: [TestTree]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -1,0 +1,32 @@
+-- | Property tests are reified by the 'ConformanceTest' type in order to
+-- expose them to the conformance testing harness.
+-- Here, a 'TestSuite' arranges them is a rose tree like structure.
+module Test.Consensus.Genesis.TestSuite (
+    TestSuite
+  , allTheTests
+  , insert
+  , toListWithKey
+  ) where
+
+import           Test.Consensus.Genesis.Setup (ConformanceTest)
+
+-- | Sum type of all the existing genesis test properties
+-- TODO: Populate this type with the ported tests.
+data TestClass = TestClass deriving (Eq, Ord)
+
+data TestSuite a = SingleTest TestClass a
+                 | TestGroup [TestSuite a] deriving (Eq)
+
+singleton :: TestClass -> a -> TestSuite a
+singleton c t = SingleTest c t
+
+insert :: TestClass -> a -> TestSuite a -> TestSuite a
+insert c t ts@(SingleTest _ _) = TestGroup [singleton c t, ts]
+insert c t (TestGroup tss)     = TestGroup (singleton c t : tss)
+
+toListWithKey :: TestSuite a -> [(TestClass, a)]
+toListWithKey (SingleTest c x) = [(c, x)]
+toListWithKey (TestGroup tss)  = concatMap toListWithKey tss
+
+allTheTests :: TestSuite (ConformanceTest blk)
+allTheTests = undefined

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -1,32 +1,37 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
--- | A 'TestSuite' data structure to arrange 'ConformanceTest' groups
--- designed to interface between property test execution and the
+-- | A 'TestSuite' data structure for quick access to 'ConformanceTest' valuesa
+-- providing facilities to arrange them in nested hierarchical groups.
+-- It's purpose is interfacing between property test execution and the
 -- conformance testing harness.
--- They are modeled after, and can be compiled to, a tasty 'TestTree'.
 module Test.Consensus.Genesis.TestSuite (
-    TestSuite
+    Generic
+  , GenericUniverse (..)
+  , TestSuite
   , get
-  , mapKeys
+  , group
   , mkTestSuite
-  , nest
   , toTestTree
   ) where
 
+import           Data.Coerce (coerce)
 import           Data.List (partition)
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Universe.Class
+import           Data.Universe.Class (Finite (..), Universe (..))
+import           Data.Universe.Generic (GUniverse, universeGeneric)
+import           GHC.Generics (Generic (Rep))
 import           Ouroboros.Consensus.Block (BlockSupportsDiffusionPipelining,
                      ConvertRawHash, Header)
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
-import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory)
 import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
 import           Ouroboros.Consensus.Ledger.Inspect (InspectLedger)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -34,9 +39,10 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Storage.ChainDB (SerialiseDiskConstraints)
 import           Ouroboros.Consensus.Storage.LedgerDB.API
                      (CanUpgradeLedgerTables)
-import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Network.Util.ShowProxy
-import           Test.Consensus.Genesis.Setup
+import           Ouroboros.Consensus.Util.Condense (Condense, CondenseList)
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
+import           Test.Consensus.Genesis.Setup (ConformanceTest (..),
+                     runConformanceTest)
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
@@ -44,50 +50,50 @@ import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.TersePrinting (Terse)
 
+newtype GenericUniverse a = GenericUniverse a
+
+instance (Generic a, GUniverse (Rep a)) => Universe (GenericUniverse a) where
+  universe = coerce $ universeGeneric @a
+
+instance (Generic a, GUniverse (Rep a)) => Finite (GenericUniverse a)
+
 data TestSuiteData blk = TestSuiteData
-  { -- | The nested groups a test belongs to.
-    -- It is 'NonEmpty', as we need a test description/name
-    -- in order to produce a 'TestTree'. For this, the
-    -- convention is to use the 'NonEmpty.last' and nest
-    -- the test by appending.
-    prefix :: NonEmpty Prefix
+  { -- | A prefix representing a path through the test group tree.
+    -- The convention is to nest by appending, i.e. the head of the prefix
+    -- corresponds to the top-level test group.
+    tsPrefix :: [String]
 
-    -- | The test to run.
-  , test   :: ConformanceTest blk
+    -- | The test itself.
+  , tsTest   :: ConformanceTest blk
   }
-
-type Prefix = String
 
 newtype TestSuite blk key = TestSuite (Map key (TestSuiteData blk))
 
--- | Smart constructor for a 'TestSuite'.
+-- | Build a 'TestSuite' from a mapping function.
 mkTestSuite :: (Ord key, Finite key)
-            => (key -> Prefix)
-            -> (key -> ConformanceTest blk)
+            => (key -> ConformanceTest blk)
             -> TestSuite blk key
-mkTestSuite toDescription toTest = TestSuite . Map.fromList $
-  [ (k, tsData)
-  | k <- universeF
-  , let tsData = TestSuiteData { prefix = [toDescription k]
-                               , test = toTest k
-                               }
-  ]
-
-mapKeys :: Ord b => (a -> b) -> TestSuite blk a -> TestSuite blk b
-mapKeys f (TestSuite m) = TestSuite $ Map.mapKeys f m
+mkTestSuite toConformanceTest = TestSuite . Map.fromList $ do
+  k <- universeF
+  let test = toConformanceTest k
+      tsData = TestSuiteData { tsPrefix = []
+                             , tsTest = test
+                             }
+  pure (k, tsData)
 
 get :: Ord key => TestSuite blk key -> key ->  ConformanceTest blk
-get (TestSuite m) k = test $ case Map.lookup k m of
+get (TestSuite m) k = tsTest $ case Map.lookup k m of
   Just t  -> t
-  Nothing -> error "TestSuite.get: Impossible! All test classes have a value by contruction."
+  Nothing -> error "TestSuite.get: Impossible! A TestSuite is a total map."
 
-nest :: [Prefix] -> TestSuite blk key -> TestSuite blk key
-nest pfs (TestSuite m) = TestSuite $
+-- | Appends the given string to the prefix of all tests.
+group :: String -> TestSuite blk key -> TestSuite blk key
+group pfs (TestSuite m) = TestSuite $
   Map.map (\testData ->
-             testData {prefix = NonEmpty.prependList pfs $ prefix testData}) m
+             testData {tsPrefix = pfs : tsPrefix testData}) m
 
--- | Produces a single test tasty 'TestTree', along with its containing
--- groups prefixes, out a 'TestSuiteData'.
+-- | Produces a single-test tasty 'TestTree', along with its containing
+-- 'group' prefixes, out a 'TestSuiteData'.
 compileSingleTest ::
   ( Condense (StateView blk)
   , CondenseList (NodeState blk)
@@ -107,45 +113,43 @@ compileSingleTest ::
   , Terse blk
   , Condense (NodeState blk)
   ) =>
-  TestSuiteData blk -> ([Prefix], TestTree)
-compileSingleTest (TestSuiteData {prefix, test}) =
-  -- The 'last' element of the 'prefix' corresponds to the individual test
+  TestSuiteData blk -> ([String], TestTree)
+compileSingleTest (TestSuiteData {tsPrefix, tsTest}) =
+  -- The 'last' element of the 'tcPrefix' corresponds to the individual test
   -- description/name. Conversely, the 'init' corresponds to the enclosing
   -- test groups.
-  let (prefixes,testName) = (NonEmpty.init prefix, NonEmpty.last prefix)
-   in (prefixes, QC.testProperty testName (runConformanceTest test))
+  let testName = ctDescription tsTest
+   in (tsPrefix, QC.testProperty testName (runConformanceTest tsTest))
 
 -- | Recursively build test groups by following the hierarchy described by
--- the '[Prefix]'. The resulting '[TestTree]' are considered to be part
+-- the '[String]'. The resulting '[TestTree]' are considered to be part
 -- of the same top level group.
-buildGroups :: [([Prefix], TestTree)] -> [TestTree]
+buildGroups :: [([String], TestTree)] -> [TestTree]
 buildGroups entries =
   let
     -- Distinguish between tests that belong to the top level
-    -- from the nested ones.
+    -- from the nested ones (i.e. those with a non-empty prefix).
     (toplevel, nested) = partition (null . fst) entries
 
     topLevelTests :: [TestTree]
     topLevelTests = fmap snd toplevel
 
     -- Group the nested tests by their first prefix.
-    grouped :: Map Prefix [([Prefix], TestTree)]
+    grouped :: Map String [([String], TestTree)]
     grouped =
-      Map.fromListWith (<>)
-        [ (p, [(ps, t)])
-        | (p:ps, t) <- nested
-        ]
+      Map.fromListWith (<>) $ do
+        (p:ps, t) <- nested
+        pure (p, [(ps, t)])
 
     subgroups :: [TestTree]
-    subgroups =
-      [ testGroup p (buildGroups xs)
-      | (p, xs) <- Map.toList grouped
-      ]
+    subgroups = do
+      (p, xs) <- Map.toList grouped
+      pure $ testGroup p (buildGroups xs)
   in
     topLevelTests <> subgroups
 
--- | Compile a 'TestSuite' into a tasty 'TestTree', with the given 'Prefix'
--- as the top level description/name.
+-- | Compile a 'TestSuite' into a tasty 'TestTree', with the given 'String'
+-- as the top level description/name of the resulting group.
 toTestTree ::
   ( Condense (StateView blk)
   , CondenseList (NodeState blk)
@@ -165,7 +169,7 @@ toTestTree ::
   , Terse blk
   , Condense (NodeState blk)
   ) =>
-  Prefix -> TestSuite blk key -> TestTree
+  String -> TestSuite blk key -> TestTree
 toTestTree p (TestSuite m) =
   let leafs = fmap snd $ Map.toAscList m
       entries = fmap compileSingleTest leafs

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -8,20 +9,44 @@
 -- designed to interface between property test execution and the
 -- conformance testing harness.
 -- They are modeled after, and can be compiled to, a tasty 'TestTree'.
-module Test.Consensus.Genesis.TestSuite where
+module Test.Consensus.Genesis.TestSuite (
+    TestSuite
+  , get
+  , mapKeys
+  , mkTestSuite
+  , nest
+  , toTestTree
+  ) where
 
-import           Data.List.Extra (groupSortOn)
+import           Data.List (partition)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Test.Consensus.Genesis.Setup (ConformanceTest)
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Ouroboros.Consensus.Block (BlockSupportsDiffusionPipelining,
+                     ConvertRawHash, Header)
+import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
+import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.Ledger.Basics (LedgerState)
+import           Ouroboros.Consensus.Ledger.Inspect (InspectLedger)
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+                     (LedgerSupportsProtocol)
+import           Ouroboros.Consensus.Storage.ChainDB (SerialiseDiskConstraints)
+import           Ouroboros.Consensus.Storage.LedgerDB.API
+                     (CanUpgradeLedgerTables)
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Network.Util.ShowProxy
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.PeerSimulator.StateView (StateView)
+import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
+import           Test.Consensus.PointSchedule.NodeState (NodeState)
+import           Test.Tasty (TestTree, testGroup)
+import qualified Test.Tasty.QuickCheck as QC
+import           Test.Util.TersePrinting (Terse)
 
 data TestSuiteData blk = TestSuiteData
-  { prefix :: NonEmpty Prefix
-  , test   :: ConformanceTest blk
+  { prefix :: NonEmpty Prefix -- ^ The nested groups a test belongs to. The `head` corresponds to the top level.
+  , test   :: ConformanceTest blk -- ^ The test to run
   }
 
 type Prefix = String
@@ -35,8 +60,8 @@ mkTestSuite p k t = TestSuite . Map.singleton k $
                 , test = t
                 }
 
-map :: Ord b => (a -> b) -> TestSuite blk a -> TestSuite blk b
-map f (TestSuite m) = TestSuite $ Map.mapKeys f m
+mapKeys :: Ord b => (a -> b) -> TestSuite blk a -> TestSuite blk b
+mapKeys f (TestSuite m) = TestSuite $ Map.mapKeys f m
 
 get :: Ord key => TestSuite blk key -> key ->  ConformanceTest blk
 get (TestSuite m) k = test $ case Map.lookup k m of
@@ -48,5 +73,85 @@ nest pfs (TestSuite m) = TestSuite $
   Map.map (\testData ->
              testData {prefix = NonEmpty.prependList pfs $ prefix testData}) m
 
-toTestTree :: TestSuite blk key -> TestTree
-toTestTree (TestSuite m) = undefined
+-- | Produces a single test tasty 'TestTree', along with its containing
+-- groups prefixes, out a 'TestSuiteData'.
+compileSingleTest ::
+  ( Condense (StateView blk)
+  , CondenseList (NodeState blk)
+  , ShowProxy blk
+  , ShowProxy (Header blk)
+  , ConfigSupportsNode blk
+  , LedgerSupportsProtocol blk
+  , SerialiseDiskConstraints blk
+  , BlockSupportsDiffusionPipelining blk
+  , InspectLedger blk
+  , HasHardForkHistory blk
+  , ConvertRawHash blk
+  , CanUpgradeLedgerTables (LedgerState blk)
+  , HasPointScheduleTestParams blk
+  , Eq (Header blk)
+  , Eq blk
+  , Terse blk
+  , Condense (NodeState blk)
+  ) =>
+  TestSuiteData blk -> ([Prefix], TestTree)
+compileSingleTest (TestSuiteData {prefix, test}) =
+  -- The last element of the prefix corresponds to the individual test
+  -- description/name. So all test matching on `init` are in the same group level.
+  let (prefixes,testName) = (NonEmpty.init prefix, NonEmpty.last prefix)
+   in (prefixes, QC.testProperty testName (runConformanceTest test))
+
+-- | Recursively build test groups by following the hierarchy described by a
+-- the 'Prefix' list. The resulting 'TestTrees' are considered to be part
+-- of the same top level group.
+buildGroups :: [([Prefix], TestTree)] -> [TestTree]
+buildGroups entries =
+  let
+    -- Tests that belong directly at this level.
+    (here, deeper) = partition (null . fst) entries
+
+    topLevelTests :: [TestTree]
+    topLevelTests = fmap snd here
+
+    -- Group the deeper tests by their first prefix
+    grouped :: Map Prefix [([Prefix], TestTree)]
+    grouped =
+      Map.fromListWith (<>)
+        [ (p, [(ps, t)])
+        | (p:ps, t) <- deeper
+        ]
+
+    subgroups :: [TestTree]
+    subgroups =
+      [ testGroup p (buildGroups xs)
+      | (p, xs) <- Map.toList grouped
+      ]
+  in
+    topLevelTests <> subgroups
+
+-- | Compile a 'TestSuite' into a tasty 'TestTree', with the given 'Prefix'
+-- as the top level description/name.
+toTestTree ::
+  ( Condense (StateView blk)
+  , CondenseList (NodeState blk)
+  , ShowProxy blk
+  , ShowProxy (Header blk)
+  , ConfigSupportsNode blk
+  , LedgerSupportsProtocol blk
+  , SerialiseDiskConstraints blk
+  , BlockSupportsDiffusionPipelining blk
+  , InspectLedger blk
+  , HasHardForkHistory blk
+  , ConvertRawHash blk
+  , CanUpgradeLedgerTables (LedgerState blk)
+  , HasPointScheduleTestParams blk
+  , Eq (Header blk)
+  , Eq blk
+  , Terse blk
+  , Condense (NodeState blk)
+  ) =>
+  Prefix -> TestSuite blk key -> TestTree
+toTestTree p (TestSuite m) =
+  let leafs = fmap snd $ Map.toAscList m
+      entries = fmap compileSingleTest leafs
+   in testGroup p $ buildGroups entries

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -1,32 +1,79 @@
--- | Property tests are reified by the 'ConformanceTest' type in order to
--- expose them to the conformance testing harness.
--- Here, a 'TestSuite' arranges them is a rose tree like structure.
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedLists #-}
+-- | A 'TestSuite' data structure to arrange 'ConformanceTest' groups
+-- designed to interface between property test execution and the
+-- conformance testing harness.
+-- They are modeled after, and can be compiled to, a tasty 'TestTree'.
 module Test.Consensus.Genesis.TestSuite (
     TestSuite
   , allTheTests
-  , insert
-  , toListWithKey
+  , lookup
+  , mkTestTree
+  , singleton
+  , toList
   ) where
 
+import           Data.Bifunctor (first)
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Prelude hiding (lookup)
 import           Test.Consensus.Genesis.Setup (ConformanceTest)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
--- | Sum type of all the existing genesis test properties
+-- | Sum type of all the existing (genesis) test properties
 -- TODO: Populate this type with the ported tests.
-data TestClass = TestClass deriving (Eq, Ord)
+data TestProperty = TestProperty deriving (Eq, Ord, Show)
 
-data TestSuite a = SingleTest TestClass a
-                 | TestGroup [TestSuite a] deriving (Eq)
+-- | This type is analogous to a 'Tasty.Test.TestName'.
+type Description = String
 
-singleton :: TestClass -> a -> TestSuite a
-singleton c t = SingleTest c t
+-- | A /path/ through the nested hierarchy of a 'TestSuite';
+-- The notion of /test group/ consists of all 'TestSuite' values sharing a 'TestHierarchy'
+type TestHierarchy = NonEmpty Description
 
-insert :: TestClass -> a -> TestSuite a -> TestSuite a
-insert c t ts@(SingleTest _ _) = TestGroup [singleton c t, ts]
-insert c t (TestGroup tss)     = TestGroup (singleton c t : tss)
+-- | A 'TestSuite' is a collection of test arranged in (nested) groups.
+--
+-- INVARIANT: A 'TestProperty' uniquely identifies a value in a 'TestSuite'.
+newtype TestSuite a = TestSuite (Map (TestHierarchy, TestProperty) a)
+  deriving (Eq, Semigroup, Monoid)
 
-toListWithKey :: TestSuite a -> [(TestClass, a)]
-toListWithKey (SingleTest c x) = [(c, x)]
-toListWithKey (TestGroup tss)  = concatMap toListWithKey tss
+lookup :: TestProperty -> TestSuite a -> Maybe a
+lookup prop (TestSuite testMap) = Map.lookup prop $ Map.mapKeys snd testMap
+
+-- | A singleton 'TestSuite' corresponds to a leaf in the test tree.
+singleton :: Description -> TestProperty -> a -> TestSuite a
+singleton pf prop test = TestSuite $ Map.singleton ([pf],prop) test
+
+nest :: TestHierarchy -> TestSuite a -> TestSuite a
+nest h (TestSuite testMap) = TestSuite $ Map.mapKeys (first (h <>)) testMap
+
+addTestSuiteToGroup :: TestHierarchy -> TestSuite a -> TestSuite a -> TestSuite a
+addTestSuiteToGroup h suite = (nest h suite <>)
+
+pickGroup :: TestHierarchy -> TestSuite a -> TestSuite a
+pickGroup h0 (TestSuite testMap) =
+  TestSuite $ Map.filterWithKey (\(h, _) _ ->
+                                   NonEmpty.isPrefixOf (NonEmpty.toList h0) h
+                                )
+                                testMap
+
+
+toList :: TestSuite a -> [((TestHierarchy, TestProperty), a)]
+toList (TestSuite testMap)= Map.toList $ testMap
+
+mkSingleTest :: Testable a => TestHierarchy -> a -> TestTree
+mkSingleTest hierarchy t = testProperty (NonEmpty.head hierarchy) t
+
+allSingleTests :: Testable a => TestSuite a -> [TestTree]
+allSingleTests (TestSuite testMap) =
+  Map.elems $ Map.mapWithKey (\(h,_) -> mkSingleTest h) testMap
+
+-- | Compile a 'TestSuite' to a tasty 'TestTree'.
+mkTestTree :: TestSuite a -> TestTree
+mkTestTree (TestSuite testMap)= undefined
 
 allTheTests :: TestSuite (ConformanceTest blk)
 allTheTests = undefined

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -50,6 +50,8 @@ import           Test.Tasty (TestTree, testGroup)
 import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.TersePrinting (Terse)
 
+-- | A data type with generically defined  'Universe' and 'Finite' instances.
+-- Intended to derive said instances (via @DerivingVia@ extension) for 'TestSuite' keys.
 newtype GenericUniverse a = GenericUniverse a
 
 instance (Generic a, GUniverse (Rep a)) => Universe (GenericUniverse a) where
@@ -67,6 +69,7 @@ data TestSuiteData blk = TestSuiteData
   , tsTest   :: ConformanceTest blk
   }
 
+-- | A @TestSuite blk key@ contains one 'ConformanceTest'@blk@ for each @key@.
 newtype TestSuite blk key = TestSuite (Map key (TestSuiteData blk))
 
 -- | Build a 'TestSuite' from a mapping function.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -50,13 +50,13 @@ tests =
     "CSJ"
     [ testGroup
         "Happy Path"
-        [ testProperty "honest peers are synchronised" $ prop_CSJ NoAdversaries OneScheduleForAllPeers,
-          testProperty "honest peers do their own thing" $ prop_CSJ NoAdversaries OneSchedulePerHonestPeer
+        [ testProperty "honest peers are synchronised" $ prop_CSJ "honest peers are synchronised" NoAdversaries OneScheduleForAllPeers,
+          testProperty "honest peers do their own thing" $ prop_CSJ "honest peers do their own thing" NoAdversaries OneSchedulePerHonestPeer
         ],
       testGroup
         "With some adversaries"
-        [ testProperty "honest peers are synchronised" $ prop_CSJ WithAdversaries OneScheduleForAllPeers,
-          testProperty "honest peers do their own thing" $ prop_CSJ WithAdversaries OneSchedulePerHonestPeer
+        [ testProperty "honest peers are synchronised" $ prop_CSJ "honest peers are synchronised" WithAdversaries OneScheduleForAllPeers,
+          testProperty "honest peers do their own thing" $ prop_CSJ "honest peers do their own thing" WithAdversaries OneSchedulePerHonestPeer
         ]
     ]
 
@@ -89,9 +89,9 @@ data NumHonestSchedulesFlag = OneScheduleForAllPeers | OneSchedulePerHonestPeer
 -- duplication of headers, but only in a window of @jumpSize@ slots near the tip
 -- of the chain.
 --
-prop_CSJ :: WithAdversariesFlag -> NumHonestSchedulesFlag -> Property
-prop_CSJ adversariesFlag numHonestSchedules =
-  runConformanceTest @TestBlock $ test_csj adversariesFlag numHonestSchedules
+prop_CSJ :: String -> WithAdversariesFlag -> NumHonestSchedulesFlag -> Property
+prop_CSJ description adversariesFlag numHonestSchedules =
+  runConformanceTest @TestBlock $ test_csj description adversariesFlag numHonestSchedules
 
 test_csj :: forall blk.
   ( HasHeader blk
@@ -100,12 +100,12 @@ test_csj :: forall blk.
   , Ord blk
   , Condense (Header blk)
   , Eq (Header blk)
-  ) => WithAdversariesFlag -> NumHonestSchedulesFlag -> ConformanceTest blk
-test_csj adversariesFlag numHonestSchedules = do
+  ) => String -> WithAdversariesFlag -> NumHonestSchedulesFlag -> ConformanceTest blk
+test_csj description adversariesFlag numHonestSchedules = do
   let genForks = case adversariesFlag of
                    NoAdversaries   -> pure 0
                    WithAdversaries -> choose (2, 4)
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest description desiredPasses testMaxSize
     ( disableBoringTimeouts <$> case numHonestSchedules of
         OneScheduleForAllPeers ->
           genChains genForks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -492,7 +492,7 @@ test_densityDisconnectTriggersChainSel ::
   , Ord blk
   ) => ConformanceTest blk
 test_densityDisconnectTriggersChainSel =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "re-triggers chain selection on disconnection" desiredPasses testMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let ps = lowDensitySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -48,8 +48,8 @@ tests :: TestTree
 tests =
   testGroup
     "LoE"
-    [ testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts False)
-    , testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts True)
+    [ testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts "adversary does not hit timeouts" False)
+    , testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts "adversary hits timeouts" True)
     ]
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
@@ -62,12 +62,12 @@ tests =
 -- stuck at the intersection between trunk and other chain.
 --
 -- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
-prop_adversaryHitsTimeouts :: Bool -> Property
-prop_adversaryHitsTimeouts =
+prop_adversaryHitsTimeouts :: String -> Bool -> Property
+prop_adversaryHitsTimeouts description =
   -- Here we can't shrink because we exploit the properties of the point schedule to wait
   -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
   -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
-  noShrinking . runConformanceTest @TestBlock . test_adversaryHitsTimeouts
+  noShrinking . runConformanceTest @TestBlock . test_adversaryHitsTimeouts description
 
 
 test_adversaryHitsTimeouts ::
@@ -75,9 +75,9 @@ test_adversaryHitsTimeouts ::
   , HasHeader (Header blk)
   , IssueTestBlock blk
   , Ord blk
-  ) => Bool -> ConformanceTest blk
-test_adversaryHitsTimeouts timeoutsEnabled =
-    mkConformanceTest desiredPasses testMaxSize
+  ) => String -> Bool -> ConformanceTest blk
+test_adversaryHitsTimeouts description timeoutsEnabled =
+    mkConformanceTest description desiredPasses testMaxSize
       ( do
           gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
           let ps = delaySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -57,7 +57,7 @@ test_longRangeAttack ::
   , Ord blk
   ) => ConformanceTest blk
 test_longRangeAttack =
-  mkConformanceTest desiredPasses id
+  mkConformanceTest "one adversary" desiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -161,7 +161,7 @@ test_serveAdversarialBranches ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_serveAdversarialBranches =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "serve adversarial branches" desiredPasses testMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
@@ -230,7 +230,7 @@ test_leashingAttackStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackStalling =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "stalling leashing attack" desiredPasses testMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
@@ -287,7 +287,7 @@ test_leashingAttackTimeLimited :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackTimeLimited =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "time limited leashing attack" desiredPasses testMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
@@ -379,7 +379,7 @@ test_loeStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_loeStalling =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" desiredPasses testMaxSize
 
     (do gt <- genChains (QC.choose (1, 4))
                 `enrichedWith`
@@ -427,7 +427,7 @@ test_downtime ::
   , Ord blk
   ) => ConformanceTest blk
 test_downtime =
-  mkConformanceTest desiredPasses (testMaxSize . const 10)
+  mkConformanceTest "the node is shut down and restarted after some time" desiredPasses (testMaxSize . const 10)
 
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
@@ -473,7 +473,7 @@ test_blockFetchLeashingAttack :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_blockFetchLeashingAttack =
-  mkConformanceTest desiredPasses testMaxSize
+  mkConformanceTest "block fetch leashing attack" desiredPasses testMaxSize
 
     (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -51,7 +51,7 @@ test_chainSyncKillsBlockFetch ::
   , Eq blk
   ) => ConformanceTest blk
 test_chainSyncKillsBlockFetch =
-  mkConformanceTest id id
+  mkConformanceTest "ChainSync kills BlockFetch" id id
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)
     )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -58,7 +58,7 @@ test_rollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_rollback =
-  mkConformanceTest desiredPasses id
+  mkConformanceTest "can rollback" desiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain, such that we can rollback
         -- from the trunk to that chain.
@@ -89,7 +89,7 @@ test_cannotRollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_cannotRollback =
-  mkConformanceTest desiredPasses id
+  mkConformanceTest "cannot rollback" desiredPasses id
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule = rollbackSchedule (fromIntegral (unNonZero $ maxRollbacks gtSecurityParam) + 1) gtBlockTree})
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -40,12 +40,12 @@ desiredPasses = (`div` 10)
 
 tests :: TestTree
 tests = testGroup "timeouts"
-  [ testProperty "does time out" (prop_timeouts True)
-  , testProperty "does not time out" (prop_timeouts False)
+  [ testProperty "does time out" (prop_timeouts "does time out" True)
+  , testProperty "does not time out" (prop_timeouts "does not time out" False)
   ]
 
-prop_timeouts :: Bool -> Property
-prop_timeouts = runConformanceTest @TestBlock . test_timeouts
+prop_timeouts :: String -> Bool -> Property
+prop_timeouts description = runConformanceTest @TestBlock . test_timeouts description
 
 test_timeouts ::
   ( IssueTestBlock blk
@@ -53,9 +53,9 @@ test_timeouts ::
   , AF.HasHeader (Header blk)
   , Condense (HeaderHash blk)
   , Condense (Header blk)
-  ) => Bool -> ConformanceTest blk
-test_timeouts mustTimeout =
-  mkConformanceTest desiredPasses id
+  ) => String -> Bool -> ConformanceTest blk
+test_timeouts description mustTimeout =
+  mkConformanceTest description desiredPasses id
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)


### PR DESCRIPTION
# Description

Closes tweag/cardano-conformance-testing-of-consensus#73

A `TestSuite` is a total map from *key* data types representing test classes to `ConformanceTest` values (which are used to run the property tests). By means of `mkTestSuite` and `group`, the resulting `TestSuite` can encode the hierarchical structure needed to compile it to a tasty `TestTree` using a prefix to each test representing a path through the tree.

The general idea is for the key types to contain a nullary constructor for each individual `ConformanceTest` value; then we will define higher order key types whose `TestSuite`s are build from those of its components.

NOTE: For this design to work, the `ConformanceTest` was enriched to contain a test description ( the `ctDescription` field). Some redundancy remains within the existing `TestTree` definitions. This would be fixed in follow up work when migrating all the tests into `TestSuite`s.