### PR TITLE
Port genesis tests to ConformanceTest type

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -1,17 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
-module Test.Consensus.Genesis.Tests.CSJ (tests) where
+module Test.Consensus.Genesis.Tests.CSJ (
+    test_csj
+  , tests
+  ) where
 
 import           Data.List (nub)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Ouroboros.Consensus.Block (Header, blockSlot, succWithOrigin,
-                     unSlotNo)
+import           Ouroboros.Consensus.Block (HasHeader, Header, blockSlot,
+                     succWithOrigin, unSlotNo)
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (TraceChainSyncClientEvent (..))
-import           Ouroboros.Consensus.Util.Condense (PaddingDirection (..),
-                     condenseListWithPadding)
+import           Ouroboros.Consensus.Util.Condense (Condense,
+                     PaddingDirection (..), condenseListWithPadding)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Protocol.ChainSync.Codec
                      (ChainSyncTimeout (mustReplyTimeout), idleTimeout)
@@ -31,26 +37,28 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock)
-import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
-                     adjustQuickCheckTests)
+
+desiredPasses :: Int -> Int
+desiredPasses = (* 10)
+
+testMaxSize :: Int -> Int
+testMaxSize = (`div` 5)
 
 tests :: TestTree
 tests =
-  adjustQuickCheckTests (* 10) $
-  adjustQuickCheckMaxSize (`div` 5) $
-    testGroup
-      "CSJ"
-      [ testGroup
-          "Happy Path"
-          [ testProperty "honest peers are synchronised" $ prop_CSJ NoAdversaries OneScheduleForAllPeers,
-            testProperty "honest peers do their own thing" $ prop_CSJ NoAdversaries OneSchedulePerHonestPeer
-          ],
-        testGroup
-          "With some adversaries"
-          [ testProperty "honest peers are synchronised" $ prop_CSJ WithAdversaries OneScheduleForAllPeers,
-            testProperty "honest peers do their own thing" $ prop_CSJ WithAdversaries OneSchedulePerHonestPeer
-          ]
-      ]
+  testGroup
+    "CSJ"
+    [ testGroup
+        "Happy Path"
+        [ testProperty "honest peers are synchronised" $ prop_CSJ NoAdversaries OneScheduleForAllPeers,
+          testProperty "honest peers do their own thing" $ prop_CSJ NoAdversaries OneSchedulePerHonestPeer
+        ],
+      testGroup
+        "With some adversaries"
+        [ testProperty "honest peers are synchronised" $ prop_CSJ WithAdversaries OneScheduleForAllPeers,
+          testProperty "honest peers do their own thing" $ prop_CSJ WithAdversaries OneSchedulePerHonestPeer
+        ]
+    ]
 
 -- | A flag to indicate if properties are tested with adversarial peers
 data WithAdversariesFlag = NoAdversaries | WithAdversaries
@@ -82,11 +90,22 @@ data NumHonestSchedulesFlag = OneScheduleForAllPeers | OneSchedulePerHonestPeer
 -- of the chain.
 --
 prop_CSJ :: WithAdversariesFlag -> NumHonestSchedulesFlag -> Property
-prop_CSJ adversariesFlag numHonestSchedules = do
+prop_CSJ adversariesFlag numHonestSchedules =
+  runConformanceTest @TestBlock $ test_csj adversariesFlag numHonestSchedules
+
+test_csj :: forall blk.
+  ( HasHeader blk
+  , HasHeader (Header blk)
+  , IssueTestBlock blk
+  , Ord blk
+  , Condense (Header blk)
+  , Eq (Header blk)
+  ) => WithAdversariesFlag -> NumHonestSchedulesFlag -> ConformanceTest blk
+test_csj adversariesFlag numHonestSchedules = do
   let genForks = case adversariesFlag of
                    NoAdversaries   -> pure 0
                    WithAdversaries -> choose (2, 4)
-  forAllGenesisTest
+  mkConformanceTest desiredPasses testMaxSize
     ( disableBoringTimeouts <$> case numHonestSchedules of
         OneScheduleForAllPeers ->
           genChains genForks
@@ -151,7 +170,7 @@ prop_CSJ adversariesFlag numHonestSchedules = do
           receivedHeadersAtMostOnceFromHonestPeers
     )
   where
-    genDuplicatedHonestSchedule :: GenesisTest TestBlock () -> Gen (PointSchedule TestBlock)
+    genDuplicatedHonestSchedule :: GenesisTest blk () -> Gen (PointSchedule blk)
     genDuplicatedHonestSchedule gt@GenesisTest {gtExtraHonestPeers} = do
       ps@PointSchedule {psSchedule = Peers {honestPeers, adversarialPeers}} <- genUniformSchedulePoints gt
       pure $ ps {
@@ -165,7 +184,7 @@ prop_CSJ adversariesFlag numHonestSchedules = do
             (Peers Map.empty adversarialPeers)
         }
 
-    isNewerThanJumpSizeFromTip :: GenesisTestFull TestBlock -> Header TestBlock -> Bool
+    isNewerThanJumpSizeFromTip :: GenesisTestFull blk -> Header blk -> Bool
     isNewerThanJumpSizeFromTip gt hdr =
       let jumpSize = csjpJumpSize $ gtCSJParams gt
           tipSlot = AF.headSlot $ btTrunk $ gtBlockTree gt

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -5,32 +5,37 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Consensus.Genesis.Tests.LongRangeAttack (tests) where
+module Test.Consensus.Genesis.Tests.LongRangeAttack (
+    test_longRangeAttack
+  , tests
+  ) where
 
 import           Data.Functor (($>))
+import           Ouroboros.Consensus.Block.Abstract (GetHeader)
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
                      (allAdversariesForecastable, allAdversariesSelectable,
                      classifiers)
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
-import           Test.Consensus.PointSchedule
+import qualified Test.Consensus.PointSchedule as Schedule
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
-import           Test.Util.TestEnv (adjustQuickCheckTests)
+
+desiredPasses :: Int -> Int
+desiredPasses = (`div` 10)
 
 tests :: TestTree
 tests =
-  testGroup "long range attack" [
-    -- NOTE: We want to keep this test to show that Praos is vulnerable to this
-    -- attack but Genesis is not. This requires to first fix it as mentioned
-    -- above.
-    --
-    adjustQuickCheckTests (`div` 10) $
-    testProperty "one adversary" prop_longRangeAttack
-  ]
+  testGroup "long range attack"
+    [ -- NOTE: We want to keep this test to show that Praos is vulnerable to this
+      -- attack but Genesis is not. This requires to first fix it as mentioned
+      -- above.
+      testProperty "one adversary" prop_longRangeAttack
+    ]
 
 -- | This test case features a long-range attack with one adversary. The honest
 -- peer serves the block tree trunk, while the adversary serves its own chain,
@@ -42,14 +47,22 @@ prop_longRangeAttack :: Property
 prop_longRangeAttack =
   -- NOTE: `shrinkPeerSchedules` only makes sense for tests that expect the
   -- honest node to win. Hence the `noShrinking`.
+  noShrinking $ runConformanceTest @TestBlock test_longRangeAttack
 
-  noShrinking $ forAllGenesisTest @TestBlock
-
+test_longRangeAttack ::
+   forall blk.
+  ( AF.HasHeader blk
+  , GetHeader blk
+  , IssueTestBlock blk
+  , Ord blk
+  ) => ConformanceTest blk
+test_longRangeAttack =
+  mkConformanceTest desiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)
         -- Create a 'longRangeAttack' schedule based on the generated chains.
-        ps <- stToGen (longRangeAttack gtBlockTree)
+        ps <- Schedule.stToGen (Schedule.longRangeAttack gtBlockTree)
         let cls = classifiers gt
         if allAdversariesSelectable cls && allAdversariesForecastable cls
           then pure $ gt $> ps


### PR DESCRIPTION
# Description

Closes tweag/cardano-conformance-testing-of-consensus#74

This PR refactors the existing genesis tests to use `runConformanceTest` instead of the `forAllGenesisTest` helper (which is now efectively deprecated and removed). As a key part of this operation, for each of the tests a `ConformanceTest` value is built and exported. This value includes all data relevant to the corresponding test run; the `desiredPasses` filed is updated to a transformation of the relevant default parameter, and a new field is included to account for the adjustment of the test case _max size_. 