### PR TITLE
Move conformance tests into test suites

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -20,7 +20,7 @@ module Test.Consensus.Genesis.TestSuite (
   , TestSuite
   , Universe
   , at
-  , get
+  , getTest
   , group
   , mkTestSuite
   , newTestSuite
@@ -113,8 +113,8 @@ at (TestSuite m) k = case Map.lookup k m of
   Just t  -> t
   Nothing -> error "TestSuite.get: Impossible! A TestSuite is a total map."
 
-get :: Ord key => TestSuite blk key -> key ->  ConformanceTest blk
-get suite = tsTest . at suite
+getTest :: TestSuiteData blk ->  ConformanceTest blk
+getTest = tsTest
 
 -- | Appends the given string to the prefix of all tests.
 group :: String -> TestSuite blk key -> TestSuite blk key

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -1,19 +1,54 @@
-module Test.Consensus.Genesis.Tests (tests) where
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 
+module Test.Consensus.Genesis.Tests (
+    GenesisTests
+  , testSuite
+  , tests
+  ) where
+
+import           Ouroboros.Consensus.Block.Abstract (GetHeader, HasHeader,
+                     Header)
+import           Ouroboros.Consensus.Util.Condense (Condense)
+import           Test.Consensus.Genesis.Setup
 import qualified Test.Consensus.Genesis.Tests.CSJ as CSJ
 import qualified Test.Consensus.Genesis.Tests.DensityDisconnect as GDD
 import qualified Test.Consensus.Genesis.Tests.LoE as LoE
 import qualified Test.Consensus.Genesis.Tests.LongRangeAttack as LongRangeAttack
 import qualified Test.Consensus.Genesis.Tests.LoP as LoP
 import qualified Test.Consensus.Genesis.Tests.Uniform as Uniform
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Tasty
+import           Test.Util.TestBlock (TestBlock)
 
 tests :: TestTree
-tests = testGroup "Genesis tests"
-    [ CSJ.tests
-    , GDD.tests
-    , LongRangeAttack.tests
-    , LoE.tests
-    , LoP.tests
-    , Uniform.tests
-    ]
+tests = testGroup "Genesis tests" $
+  [GDD.tests] <> toTestTree @TestBlock testSuite
+
+data GenesisTests = Uniform !Uniform.Test
+                  | CSJ !CSJ.Test
+                  | GDD !GDD.Test
+                  | LRA !LongRangeAttack.Test
+                  | LoE !LoE.Test
+                  | LoP !LoP.Test
+                 deriving stock (Eq, Ord, Generic)
+                 deriving (Universe, Finite) via GenericUniverse GenesisTests
+
+testSuite ::
+  ( HasHeader blk
+  , GetHeader blk
+  , IssueTestBlock blk
+  , Condense (Header blk)
+  , Ord blk
+  , Eq (Header blk)
+  ) => TestSuite blk GenesisTests
+testSuite = mkTestSuite $ \case
+  Uniform t -> at Uniform.testSuite t
+  CSJ t -> at CSJ.testSuite t
+  GDD t -> at GDD.testSuite t
+  LRA t -> at LongRangeAttack.testSuite t
+  LoE t -> at LoE.testSuite t
+  LoP t -> at LoP.testSuite t

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -32,7 +32,7 @@ tests = testGroup "Genesis tests" $
 data GenesisTestKey = Uniform !Uniform.TestKey
              | CSJ !CSJ.TestKey
              | GDD !GDD.TestKey
-             | LRA !LongRangeAttack.TestKey
+             | LongRangeAttack !LongRangeAttack.TestKey
              | LoE !LoE.TestKey
              | LoP !LoP.TestKey
   deriving stock (Eq, Ord, Generic)
@@ -50,6 +50,6 @@ testSuite = mkTestSuite $ \case
   Uniform t -> at Uniform.testSuite t
   CSJ t -> at CSJ.testSuite t
   GDD t -> at GDD.testSuite t
-  LRA t -> at LongRangeAttack.testSuite t
+  LongRangeAttack t -> at LongRangeAttack.testSuite t
   LoE t -> at LoE.testSuite t
   LoP t -> at LoP.testSuite t

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Consensus.Genesis.Tests (
-    GenesisTests
+    GenesisTestKey
   , testSuite
   , tests
   ) where
@@ -28,14 +28,15 @@ tests :: TestTree
 tests = testGroup "Genesis tests" $
   [GDD.tests] <> toTestTree @TestBlock testSuite
 
-data GenesisTests = Uniform !Uniform.Test
-                  | CSJ !CSJ.Test
-                  | GDD !GDD.Test
-                  | LRA !LongRangeAttack.Test
-                  | LoE !LoE.Test
-                  | LoP !LoP.Test
-                 deriving stock (Eq, Ord, Generic)
-                 deriving (Universe, Finite) via GenericUniverse GenesisTests
+-- | Each value of this type uniquely corresponds to a Genesis test.
+data GenesisTestKey = Uniform !Uniform.TestKey
+             | CSJ !CSJ.TestKey
+             | GDD !GDD.TestKey
+             | LRA !LongRangeAttack.TestKey
+             | LoE !LoE.TestKey
+             | LoP !LoP.TestKey
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse GenesisTestKey
 
 testSuite ::
   ( HasHeader blk
@@ -44,7 +45,7 @@ testSuite ::
   , Condense (Header blk)
   , Ord blk
   , Eq (Header blk)
-  ) => TestSuite blk GenesisTests
+  ) => TestSuite blk GenesisTestKey
 testSuite = mkTestSuite $ \case
   Uniform t -> at Uniform.testSuite t
   CSJ t -> at CSJ.testSuite t

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -38,9 +38,13 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Default adjustment of required property test passes.
+-- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (* 10)
 
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -124,6 +124,7 @@ test_csj description adversariesFlag numHonestSchedules = do
           genChainsWithExtraHonestPeers (choose (2, 4)) genForks
           `enrichedWith` genUniformSchedulePoints
     )
+
     ( defaultSchedulerConfig
       { scEnableCSJ = True
       , scEnableLoE = True
@@ -137,7 +138,9 @@ test_csj description adversariesFlag numHonestSchedules = do
       -- downloaded.
       }
     )
+
     shrinkPeerSchedules
+
     ( \gt StateView{svTrace} ->
         let
           -- The list of 'TraceDownloadedHeader' events that are not newer than

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -7,7 +7,7 @@
 
 -- | ChainSync Jumping tests.
 module Test.Consensus.Genesis.Tests.CSJ (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -41,17 +41,18 @@ import           Test.Util.PartialAccessors
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (* 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-testMaxSize :: Int -> Int
-testMaxSize = (`div` 5)
+adjustTestMaxSize :: Int -> Int
+adjustTestMaxSize = (`div` 5)
 
-data Test = ChainSyncJump !WithAdversariesFlag !NumHonestSchedulesFlag
-          deriving stock (Eq, Ord, Generic)
-          deriving (Universe, Finite) via (GenericUniverse Test)
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = ChainSyncJump !WithAdversariesFlag !NumHonestSchedulesFlag
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( HasHeader blk
@@ -60,7 +61,7 @@ testSuite ::
   , Ord blk
   , Condense (Header blk)
   , Eq (Header blk)
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "CSJ" $ newTestSuite $ \case
   ChainSyncJump NoAdversaries OneScheduleForAllPeers ->
     test_csj "adversary free: honest peers are synchronised" NoAdversaries OneScheduleForAllPeers
@@ -114,7 +115,7 @@ test_csj description adversariesFlag numHonestSchedules = do
   let genForks = case adversariesFlag of
                    NoAdversaries   -> pure 0
                    WithAdversaries -> choose (2, 4)
-  mkConformanceTest description desiredPasses testMaxSize
+  mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
     ( disableBoringTimeouts <$> case numHonestSchedules of
         OneScheduleForAllPeers ->
           genChains genForks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -71,9 +71,13 @@ import           Test.Util.TersePrinting (terseHFragment, terseHWTFragment,
                      terseHeader)
 import           Test.Util.TestBlock (TestBlock, singleNodeTestConfig)
 
+-- | Default adjustment of required property test passes.
+-- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (* 10)
 
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -1,12 +1,15 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- | Genesis density disconnect tests.
 module Test.Consensus.Genesis.Tests.DensityDisconnect (
-    test_densityDisconnectTriggersChainSel
+    Test
+  , testSuite
   , tests
   ) where
 
@@ -47,6 +50,7 @@ import           Test.Consensus.BlockTree
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers (classifiers,
                      genesisWindowAfterIntersection)
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.Run
                      (SchedulerConfig (scEnableLoE), defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
@@ -81,15 +85,24 @@ desiredPasses = (* 10)
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 
+data Test = TriggersChainSelection
+  deriving stock (Eq,Ord,Generic)
+  deriving (Universe, Finite) via GenericUniverse Test
+
+testSuite ::
+  ( HasHeader blk
+  , IssueTestBlock blk
+  , Ord blk
+  ) => TestSuite blk Test
+testSuite = group "density disconnect" $ newTestSuite $ \case
+  TriggersChainSelection -> test_densityDisconnectTriggersChainSel
+
 tests :: TestTree
 tests =
-  testGroup "gdd" [
-    -- TODO: Migrate this two non-genesis-test properties?
-    -- NOTE: They are applied the same adjustments.
-    testProperty "basic" prop_densityDisconnectStatic,
-    testProperty "monotonicity" prop_densityDisconnectMonotonic,
-    testProperty "re-triggers chain selection on disconnection" prop_densityDisconnectTriggersChainSel
-  ]
+  testGroup "density disconnect"
+    [ testProperty "basic" prop_densityDisconnectStatic
+    , testProperty "monotonicity" prop_densityDisconnectMonotonic
+    ]
 
 branchTip :: AnchoredFragment TestBlock -> Tip TestBlock
 branchTip =
@@ -487,9 +500,6 @@ prop_densityDisconnectMonotonic =
 -- | Tests that a GDD disconnection re-triggers chain selection, i.e. when the current
 -- selection is blocked by LoE, and the leashing adversary reveals it is not dense enough,
 -- it gets disconnected and then the selection progresses.
-prop_densityDisconnectTriggersChainSel :: Property
-prop_densityDisconnectTriggersChainSel = runConformanceTest @TestBlock test_densityDisconnectTriggersChainSel
-
 test_densityDisconnectTriggersChainSel ::
   ( HasHeader blk
   , IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -8,7 +8,7 @@
 
 -- | Genesis density disconnect tests.
 module Test.Consensus.Genesis.Tests.DensityDisconnect (
-    Test
+    TestKey
   , testSuite
   , tests
   ) where
@@ -77,23 +77,24 @@ import           Test.Util.TestBlock (TestBlock, singleNodeTestConfig)
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (* 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-testMaxSize :: Int -> Int
-testMaxSize = (`div` 5)
+adjustTestMaxSize :: Int -> Int
+adjustTestMaxSize = (`div` 5)
 
-data Test = TriggersChainSelection
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = TriggersChainSelection
   deriving stock (Eq,Ord,Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( HasHeader blk
   , IssueTestBlock blk
   , Ord blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "density disconnect" $ newTestSuite $ \case
   TriggersChainSelection -> test_densityDisconnectTriggersChainSel
 
@@ -506,7 +507,7 @@ test_densityDisconnectTriggersChainSel ::
   , Ord blk
   ) => ConformanceTest blk
 test_densityDisconnectTriggersChainSel =
-  mkConformanceTest "re-triggers chain selection on disconnection" desiredPasses testMaxSize
+  mkConformanceTest "re-triggers chain selection on disconnection" adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let ps = lowDensitySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
+-- | Limit on Eagerness tests.
 module Test.Consensus.Genesis.Tests.LoE (
-    test_adversaryHitsTimeouts
-  , tests
+    Test
+  , testSuite
   ) where
 
 import           Data.Functor (($>))
@@ -20,6 +22,7 @@ import           Ouroboros.Network.Driver.Limits
                      (ProtocolLimitFailure (ExceededTimeLimit))
 import           Test.Consensus.BlockTree (BlockTree (..), BlockTreeBranch (..))
 import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
@@ -28,11 +31,9 @@ import           Test.Consensus.PointSchedule.Peers (peers')
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Test.QuickCheck (noShrinking)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
-import           Test.Util.TestBlock (TestBlock)
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
@@ -44,13 +45,21 @@ desiredPasses = (* 10)
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 
-tests :: TestTree
-tests =
-  testGroup
-    "LoE"
-    [ testProperty "adversary does not hit timeouts" (prop_adversaryHitsTimeouts "adversary does not hit timeouts" False)
-    , testProperty "adversary hits timeouts" (prop_adversaryHitsTimeouts "adversary hits timeouts" True)
-    ]
+data Test = AdversaryHitsTimeouts !Bool
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse Test
+
+testSuite ::
+  ( HasHeader blk
+  , HasHeader (Header blk)
+  , IssueTestBlock blk
+  , Ord blk
+  ) => TestSuite blk Test
+testSuite = group "LoE" $ newTestSuite $ \case
+  AdversaryHitsTimeouts True ->
+    test_adversaryHitsTimeouts "adversary does not hit timeouts" False
+  AdversaryHitsTimeouts False ->
+    test_adversaryHitsTimeouts "adversary hits timeouts" True
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
 -- killed by something that is not LoE-aware, eg. the timeouts. This test
@@ -62,14 +71,6 @@ tests =
 -- stuck at the intersection between trunk and other chain.
 --
 -- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
-prop_adversaryHitsTimeouts :: String -> Bool -> Property
-prop_adversaryHitsTimeouts description =
-  -- Here we can't shrink because we exploit the properties of the point schedule to wait
-  -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
-  -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
-  noShrinking . runConformanceTest @TestBlock . test_adversaryHitsTimeouts description
-
-
 test_adversaryHitsTimeouts ::
   ( HasHeader blk
   , HasHeader (Header blk)
@@ -105,7 +106,12 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
                 [] -> not timeoutsEnabled
                 [fromException -> Just (ExceededTimeLimit _)] -> timeoutsEnabled
                 _ -> False
-           in selectedCorrect && exceptionsCorrect
+              -- Here we can't shrink because we exploit the properties of the
+              -- point schedule to wait at the end of the test for the
+              -- adversaries to get disconnected, by adding an extra point.
+              -- If this point gets removed by the shrinker, we lose that
+              -- property and the test becomes useless.
+           in noShrinking $ selectedCorrect && exceptionsCorrect
       )
   where
     delaySchedule :: HasHeader blk => BlockTree blk -> PointSchedule blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -34,12 +34,12 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock)
 
--- | General adjustment of required property test passes.
+-- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (* 10)
 
--- | General adjustment of max test case size.
+-- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -95,7 +95,7 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
       -- adversaries to get disconnected, by adding an extra point.
       -- If this point gets removed by the shrinker, we lose that
       -- property and the test becomes useless.
-      (\_ _ -> mempty)
+      mempty
 
       ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
           let -- The tip of the blocktree trunk.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -28,10 +28,8 @@ import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.Peers (peers')
-import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
-import           Test.QuickCheck (noShrinking)
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 
@@ -55,7 +53,6 @@ testSuite ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
-  , Ord blk
   ) => TestSuite blk TestKey
 testSuite = group "LoE" $ newTestSuite $ \case
   AdversaryDoesNotHitTimeouts ->
@@ -77,7 +74,6 @@ test_adversaryHitsTimeouts ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
-  , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_adversaryHitsTimeouts description timeoutsEnabled =
     mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
@@ -93,7 +89,14 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
             scEnableLoP = False
           }
       )
-      shrinkPeerSchedules
+      
+      -- Here we can't shrink because we exploit the properties of the
+      -- point schedule to wait at the end of the test for the
+      -- adversaries to get disconnected, by adding an extra point.
+      -- If this point gets removed by the shrinker, we lose that
+      -- property and the test becomes useless.
+      (\_ _ -> mempty)
+      
       ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
           let -- The tip of the blocktree trunk.
               treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
@@ -108,12 +111,7 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
                 [] -> not timeoutsEnabled
                 [fromException -> Just (ExceededTimeLimit _)] -> timeoutsEnabled
                 _ -> False
-              -- Here we can't shrink because we exploit the properties of the
-              -- point schedule to wait at the end of the test for the
-              -- adversaries to get disconnected, by adding an extra point.
-              -- If this point gets removed by the shrinker, we lose that
-              -- property and the test becomes useless.
-           in noShrinking $ selectedCorrect && exceptionsCorrect
+           in selectedCorrect && exceptionsCorrect
       )
   where
     delaySchedule :: HasHeader blk => BlockTree blk -> PointSchedule blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -89,14 +89,14 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
             scEnableLoP = False
           }
       )
-      
+
       -- Here we can't shrink because we exploit the properties of the
       -- point schedule to wait at the end of the test for the
       -- adversaries to get disconnected, by adding an extra point.
       -- If this point gets removed by the shrinker, we lose that
       -- property and the test becomes useless.
       (\_ _ -> mempty)
-      
+
       ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
           let -- The tip of the blocktree trunk.
               treeTipPoint = AF.headPoint $ btTrunk gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -9,7 +9,7 @@
 
 -- | Limit on Eagerness tests.
 module Test.Consensus.Genesis.Tests.LoE (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -37,28 +37,30 @@ import           Test.Util.PartialAccessors
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (* 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-testMaxSize :: Int -> Int
-testMaxSize = (`div` 5)
+adjustTestMaxSize :: Int -> Int
+adjustTestMaxSize = (`div` 5)
 
-data Test = AdversaryHitsTimeouts !Bool
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = AdversaryDoesNotHitTimeouts
+             | AdversaryHitsTimeouts
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
   , Ord blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "LoE" $ newTestSuite $ \case
-  AdversaryHitsTimeouts True ->
+  AdversaryDoesNotHitTimeouts ->
     test_adversaryHitsTimeouts "adversary does not hit timeouts" False
-  AdversaryHitsTimeouts False ->
+  AdversaryHitsTimeouts ->
     test_adversaryHitsTimeouts "adversary hits timeouts" True
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
@@ -78,7 +80,7 @@ test_adversaryHitsTimeouts ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_adversaryHitsTimeouts description timeoutsEnabled =
-    mkConformanceTest description desiredPasses testMaxSize
+    mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
       ( do
           gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
           let ps = delaySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -42,12 +42,12 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.TestBlock (TestBlock)
 
--- | General adjustment of required property test passes.
+-- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (* 10)
 
--- | General adjustment of max test case size.
+-- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
@@ -67,7 +67,7 @@ tests =
 
 -- | Simple test in which we connect to only one peer, who advertises the tip of
 -- the block tree trunk and then does nothing. If the given boolean,
--- @mustTimeout@, if @True@, then we wait just long enough for the LoP bucket to
+-- @mustTimeout@, is @True@, then we wait just long enough for the LoP bucket to
 -- empty; we expect to observe an 'EmptyBucket' exception in the ChainSync
 -- client. If @mustTimeout@ is @False@, then we wait not quite as long, so the
 -- LoP bucket should not be empty at the end of the test and we should observe
@@ -167,7 +167,7 @@ test_waitBehindForecastHorizon =
 -- slow enough to lose against the LoP bucket.
 --
 -- Let @c@ be the bucket capacity, @r@ be the bucket rate and @t@ be the time
--- between blocks, then the bucket level right right before getting the token
+-- between blocks, then the bucket level right before getting the token
 -- for the @k@th block will be:
 --
 -- > c - krt + (k-1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -36,7 +36,6 @@ import           Test.Consensus.PointSchedule.Peers (peers', peersOnlyAdversary,
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
                      scheduleHeaderPoint, scheduleTipPoint)
-import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 
@@ -106,7 +105,9 @@ test_wait description mustTimeout =
     )
     -- NOTE: Crucially, there must not be timeouts for this test.
     (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+    
     shrinkPeerSchedules
+    
     ( \_ stateView ->
         case exceptionsByComponent ChainSyncClient stateView of
           []                                           -> not mustTimeout
@@ -239,12 +240,12 @@ test_serve description mustTimeout =
         psMinEndTime = Time 0
       }
 
--- NOTE: Same as 'LoE.test_adversaryHitsTimeouts' with LoP instead of timeouts.
+-- | Same as 'Test.Consensus.Genesis.LoE.test_adversaryHitsTimeouts'
+-- with LoP instead of timeouts.
 test_delayAttack ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
-  , Ord blk
   ) =>
   String -> Bool -> ConformanceTest blk
 test_delayAttack description lopEnabled =
@@ -255,6 +256,7 @@ test_delayAttack description lopEnabled =
             ps = delaySchedule gtBlockTree
         pure $ gt' $> ps
     )
+    
     -- NOTE: Crucially, there must not be timeouts for this test.
     ( defaultSchedulerConfig
         { scEnableChainSyncTimeouts = False,
@@ -262,7 +264,14 @@ test_delayAttack description lopEnabled =
           scEnableLoP = lopEnabled
         }
     )
-    shrinkPeerSchedules
+    
+    -- Here we can't shrink because we exploit the properties of the point
+    -- schedule to wait at the end of the test for the adversaries to get
+    -- disconnected, by adding an extra point.
+    -- If this point gets removed by the shrinker, we lose that property and
+    -- the test becomes useless.
+    (\_ _ -> mempty)
+    
     ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
         let -- The tip of the blocktree trunk.
             treeTipPoint = AF.headPoint $ btTrunk gtBlockTree
@@ -278,11 +287,7 @@ test_delayAttack description lopEnabled =
               [fromException -> Just CSClient.EmptyBucket] -> lopEnabled
               _                                            -> False
 
-            -- Here we can't shrink because we exploit the properties of the point schedule to wait
-            -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
-            -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
-            -- REVIEW: Does this /inner/ call to noShrinking behaves as the outer call from before?
-         in noShrinking $ selectedCorrect && exceptionsCorrect
+         in selectedCorrect && exceptionsCorrect
     )
   where
     delaySchedule :: (HasHeader blk) => BlockTree blk -> PointSchedule blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -147,9 +147,12 @@ test_waitBehindForecastHorizon =
             gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
         pure $ gt' $> ps
     )
+
     -- NOTE: Crucially, there must not be timeouts for this test.
     (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+
     shrinkPeerSchedules
+
     ( \_ stateView ->
         case exceptionsByComponent ChainSyncClient stateView of
           [] -> True
@@ -199,9 +202,12 @@ test_serve description mustTimeout =
             gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity, lbpRate}}
         pure $ gt' $> ps
     )
+
     -- NOTE: Crucially, there must not be timeouts for this test.
     (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
+
     shrinkPeerSchedules
+
     ( \_ stateView ->
         case exceptionsByComponent ChainSyncClient stateView of
           []                                           -> not mustTimeout
@@ -270,7 +276,7 @@ test_delayAttack description lopEnabled =
     -- disconnected, by adding an extra point.
     -- If this point gets removed by the shrinker, we lose that property and
     -- the test becomes useless.
-    (\_ _ -> mempty)
+    mempty
 
     ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
         let -- The tip of the blocktree trunk.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -9,7 +9,7 @@
 
 -- | Limit on Patience tests.
 module Test.Consensus.Genesis.Tests.LoP (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -42,35 +42,39 @@ import           Test.Util.PartialAccessors
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (* 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-testMaxSize :: Int -> Int
-testMaxSize = (`div` 5)
+adjustTestMaxSize :: Int -> Int
+adjustTestMaxSize = (`div` 5)
 
-data Test = WaitUntilEmpty !Bool
-          | WaitBehindForecastHorizon
-          | ServeSlow !Bool
-          | DelayAttack !Bool
-          deriving stock (Eq, Ord, Generic)
-          deriving (Universe, Finite) via (GenericUniverse Test)
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = WaitJustEnoughUntilEmpty
+             | WaitTooMuchUntilEmpty
+             | WaitBehindForecastHorizon
+             | ServeJustFastEnough
+             | ServeTooSlow
+             | DelayAttackSucceeds
+             | DelayAttackFails
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
   , Ord blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "LoP" $ newTestSuite $ \case
-  WaitUntilEmpty False -> test_wait "wait just enough" False
-  WaitUntilEmpty True -> test_wait "wait too much" True
+  WaitJustEnoughUntilEmpty -> test_wait "wait just enough" False
+  WaitTooMuchUntilEmpty -> test_wait "wait too much" True
   WaitBehindForecastHorizon -> test_waitBehindForecastHorizon
-  ServeSlow False -> test_serve "serve just fast enough" False
-  ServeSlow True -> test_serve "serve too slow" True
-  DelayAttack False -> test_delayAttack "delaying attack succeeds without LoP" False
-  DelayAttack True -> test_delayAttack "delaying attack fails with LoP" True
+  ServeJustFastEnough -> test_serve "serve just fast enough" False
+  ServeTooSlow -> test_serve "serve too slow" True
+  DelayAttackSucceeds -> test_delayAttack "delaying attack succeeds without LoP" False
+  DelayAttackFails -> test_delayAttack "delaying attack fails with LoP" True
 
 -- | Simple test in which we connect to only one peer, who advertises the tip of
 -- the block tree trunk and then does nothing. If the given boolean,
@@ -85,14 +89,14 @@ test_wait ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_wait description mustTimeout =
-  mkConformanceTest description desiredPasses
+  mkConformanceTest description adjustDesiredPasses
 
     -- NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
     -- significantly more time than the one that does. This is because the former
     -- does all the computation (serving the headers, validating them, serving the
     -- block, validating them) while the latter does nothing, because it timeouts
     -- before reaching the last tick of the point schedule.
-    (case mustTimeout of False -> testMaxSize; True -> id)
+    (case mustTimeout of False -> adjustTestMaxSize; True -> id)
 
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
@@ -135,7 +139,7 @@ test_waitBehindForecastHorizon ::
   , Ord blk
   ) => ConformanceTest blk
 test_waitBehindForecastHorizon =
-  mkConformanceTest "wait behind forecast horizon" desiredPasses testMaxSize
+  mkConformanceTest "wait behind forecast horizon" adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let ps = dullSchedule (btTrunk gtBlockTree)
@@ -186,7 +190,7 @@ test_serve ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_serve description mustTimeout =
-  mkConformanceTest description desiredPasses testMaxSize
+  mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
@@ -244,7 +248,7 @@ test_delayAttack ::
   ) =>
   String -> Bool -> ConformanceTest blk
 test_delayAttack description lopEnabled =
-  mkConformanceTest description desiredPasses testMaxSize
+  mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -105,9 +105,9 @@ test_wait description mustTimeout =
     )
     -- NOTE: Crucially, there must not be timeouts for this test.
     (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
-    
+
     shrinkPeerSchedules
-    
+
     ( \_ stateView ->
         case exceptionsByComponent ChainSyncClient stateView of
           []                                           -> not mustTimeout
@@ -256,7 +256,7 @@ test_delayAttack description lopEnabled =
             ps = delaySchedule gtBlockTree
         pure $ gt' $> ps
     )
-    
+
     -- NOTE: Crucially, there must not be timeouts for this test.
     ( defaultSchedulerConfig
         { scEnableChainSyncTimeouts = False,
@@ -264,14 +264,14 @@ test_delayAttack description lopEnabled =
           scEnableLoP = lopEnabled
         }
     )
-    
+
     -- Here we can't shrink because we exploit the properties of the point
     -- schedule to wait at the end of the test for the adversaries to get
     -- disconnected, by adding an extra point.
     -- If this point gets removed by the shrinker, we lose that property and
     -- the test becomes useless.
     (\_ _ -> mempty)
-    
+
     ( \GenesisTest {gtBlockTree} stateView@StateView {svSelectedChain} ->
         let -- The tip of the blocktree trunk.
             treeTipPoint = AF.headPoint $ btTrunk gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -1,43 +1,51 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
+-- | Long range attack tests.
 module Test.Consensus.Genesis.Tests.LongRangeAttack (
-    test_longRangeAttack
-  , tests
+    Test
+  , testSuite
   ) where
 
 import           Data.Functor (($>))
-import           Ouroboros.Consensus.Block.Abstract (GetHeader)
+import           Ouroboros.Consensus.Block.Abstract (GetHeader, HasHeader)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
                      (allAdversariesForecastable, allAdversariesSelectable,
                      classifiers)
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import qualified Test.Consensus.PointSchedule as Schedule
 import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
-import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 10)
 
-tests :: TestTree
-tests =
-  testGroup "long range attack"
-    [ -- NOTE: We want to keep this test to show that Praos is vulnerable to this
-      -- attack but Genesis is not. This requires to first fix it as mentioned
-      -- above.
-      testProperty "one adversary" prop_longRangeAttack
-    ]
+data Test = LongRangeAttack
+  deriving stock (Eq,Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse Test
+
+testSuite ::
+   (HasHeader blk
+  , GetHeader blk
+  , IssueTestBlock blk
+  , Ord blk
+  ) => TestSuite blk Test
+testSuite = group "long range attack" $ newTestSuite $ \case
+  -- NOTE: We want to keep this test to show that Praos is vulnerable to this
+  -- attack but Genesis is not. This requires to first fix it as mentioned
+  -- above.
+  LongRangeAttack -> test_longRangeAttack
 
 -- | This test case features a long-range attack with one adversary. The honest
 -- peer serves the block tree trunk, while the adversary serves its own chain,
@@ -45,12 +53,6 @@ tests =
 -- The adversary serves the chain more rapidly than the honest peer. We check at
 -- the end that the selection is honest. This property does not hold with Praos,
 -- but should hold with Genesis.
-prop_longRangeAttack :: Property
-prop_longRangeAttack =
-  -- NOTE: `shrinkPeerSchedules` only makes sense for tests that expect the
-  -- honest node to win. Hence the `noShrinking`.
-  noShrinking $ runConformanceTest @TestBlock test_longRangeAttack
-
 test_longRangeAttack ::
    forall blk.
   ( AF.HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -25,6 +25,8 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Default adjustment of required property test passes.
+-- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 10)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -8,7 +8,7 @@
 
 -- | Long range attack tests.
 module Test.Consensus.Genesis.Tests.LongRangeAttack (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -28,19 +28,20 @@ import           Test.Util.Orphans.IOLike ()
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (`div` 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (`div` 10)
 
-data Test = LongRangeAttack
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = LongRangeAttack
   deriving stock (Eq,Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
    (HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "long range attack" $ newTestSuite $ \case
   -- NOTE: We want to keep this test to show that Praos is vulnerable to this
   -- attack but Genesis is not. This requires to first fix it as mentioned
@@ -61,7 +62,7 @@ test_longRangeAttack ::
   , Ord blk
   ) => ConformanceTest blk
 test_longRangeAttack =
-  mkConformanceTest "one adversary" desiredPasses id
+  mkConformanceTest "one adversary" adjustDesiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -74,8 +74,7 @@ test_longRangeAttack =
 
     defaultSchedulerConfig
 
-    -- NOTE: Use `shrinkPeerSchedules` when testing Genesis.
-    (\_ _ -> mempty)
+    mempty
 
     -- FIXME: This is the expected behaviour of Praos to be reversed with
     -- Genesis. But we are testing Praos for the moment. Do not forget to

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -22,7 +22,6 @@ import           Test.Consensus.Genesis.Setup.Classifiers
 import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import qualified Test.Consensus.PointSchedule as Schedule
-import           Test.Consensus.PointSchedule.Shrinking (shrinkPeerSchedules)
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 
@@ -45,7 +44,7 @@ testSuite ::
 testSuite = group "long range attack" $ newTestSuite $ \case
   -- NOTE: We want to keep this test to show that Praos is vulnerable to this
   -- attack but Genesis is not. This requires to first fix it as mentioned
-  -- above.
+  -- below.
   LongRangeAttack -> test_longRangeAttack
 
 -- | This test case features a long-range attack with one adversary. The honest
@@ -75,9 +74,11 @@ test_longRangeAttack =
 
     defaultSchedulerConfig
 
-    shrinkPeerSchedules
+    -- NOTE: Use `shrinkPeerSchedules` when testing Genesis.
+    (\_ _ -> mempty)
 
-    -- NOTE: This is the expected behaviour of Praos to be reversed with
-    -- Genesis. But we are testing Praos for the moment. Do not forget to remove
-    -- 'noShrinking' above when removing this negation.
+    -- FIXME: This is the expected behaviour of Praos to be reversed with
+    -- Genesis. But we are testing Praos for the moment. Do not forget to
+    -- use `Test.Consensus.PointSchedule.Shrinking.shrinkPeerSchedules`
+    -- above when removing this negation.
     (\genesisTest -> not . selectedHonestChain genesisTest)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -66,9 +66,13 @@ import           Test.Util.QuickCheck (le)
 import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
+-- | Default adjustment of required property test passes.
+-- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (* 10)
 
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Peer simulator tests based on randomly generated schedules. They share the
@@ -13,14 +13,9 @@
 -- other tests cases (eg. long range attack), the schedules are not particularly
 -- biased towards a specific situation.
 module Test.Consensus.Genesis.Tests.Uniform (
-    genUniformSchedulePoints
-  , test_blockFetchLeashingAttack
-  , test_downtime
-  , test_leashingAttackStalling
-  , test_leashingAttackTimeLimited
-  , test_loeStalling
-  , test_serveAdversarialBranches
-  , tests
+    Test
+  , genUniformSchedulePoints
+  , testSuite
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo (SlotNo), WithOrigin (..))
@@ -44,6 +39,7 @@ import           Ouroboros.Network.Protocol.Limits (shortWait)
 import           Test.Consensus.BlockTree (BlockTree (..), btbSuffix)
 import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.ChainSync (chainSyncNoTimeouts)
 import           Test.Consensus.PeerSimulator.Run (SchedulerConfig (..),
                      defaultSchedulerConfig)
@@ -58,12 +54,9 @@ import           Test.Consensus.PointSchedule.SinglePeer
 import           Test.Ouroboros.Consensus.ChainGenerator.Params (Delta (Delta))
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 import           Test.Util.QuickCheck (le)
-import           Test.Util.TestBlock (TestBlock)
 import           Text.Printf (printf)
 
 -- | Default adjustment of required property test passes.
@@ -76,20 +69,28 @@ desiredPasses = (* 10)
 testMaxSize :: Int -> Int
 testMaxSize = (`div` 5)
 
-tests :: TestTree
-tests =
-  testGroup "uniform"
-    [ -- See Note [Leashing attacks]
-      testProperty "stalling leashing attack" prop_leashingAttackStalling
-    , testProperty "time limited leashing attack" prop_leashingAttackTimeLimited
-    , testProperty "serve adversarial branches" prop_serveAdversarialBranches
-    , testProperty "the LoE stalls the chain, but the immutable tip is honest" prop_loeStalling
-    -- This is a crude way of ensuring that we don't get chains with more than 100 blocks,
-    -- because this test writes the immutable chain to disk and `instance Binary TestBlock`
-    -- chokes on long chains.
-    , testProperty "the node is shut down and restarted after some time" prop_downtime
-    , testProperty "block fetch leashing attack" prop_blockFetchLeashingAttack
-    ]
+data Test = BlockFetchLeashingAttack
+          | Downtime
+          | LeashingAttackStalling
+          | LeashingAttackTimeLimited
+          | LOEStalling
+          | ServeAdversarialBranches
+          deriving stock (Eq, Show, Ord, Generic)
+          deriving (Universe, Finite) via (GenericUniverse Test)
+
+testSuite ::
+  ( AF.HasHeader blk
+  , GetHeader blk
+  , IssueTestBlock blk
+  , Ord blk
+  ) => TestSuite blk Test
+testSuite = group "uniform" $ newTestSuite $ \case
+    BlockFetchLeashingAttack -> test_blockFetchLeashingAttack
+    Downtime -> test_downtime
+    LeashingAttackStalling -> test_leashingAttackStalling
+    LeashingAttackTimeLimited -> test_leashingAttackTimeLimited
+    LOEStalling -> test_loeStalling
+    ServeAdversarialBranches -> test_serveAdversarialBranches
 
 -- | The conjunction of
 --
@@ -155,9 +156,6 @@ fromBlockPoint _                                      = Nothing
 
 -- | Tests that the immutable tip is not delayed and stays honest with the
 -- adversarial peers serving adversarial branches.
-prop_serveAdversarialBranches :: Property
-prop_serveAdversarialBranches = runConformanceTest @TestBlock test_serveAdversarialBranches
-
 test_serveAdversarialBranches ::
   ( AF.HasHeader blk
   , GetHeader blk
@@ -223,10 +221,9 @@ genUniformSchedulePoints gt = stToGen (uniformPoints pointsGeneratorParams (gtBl
 -- the test at this point should cause the immutable tip to be too far behind
 -- the last genesis window of the honest chain.
 
--- | Test that the leashing attacks do not delay the immutable tip
-prop_leashingAttackStalling :: Property
-prop_leashingAttackStalling = runConformanceTest @TestBlock test_leashingAttackStalling
-
+-- | Test that the leashing attacks do not delay the immutable tip.
+--
+-- See Note [Leashing attacks]
 test_leashingAttackStalling :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
@@ -281,9 +278,6 @@ dropRandomPoints ps = do
 -- all of its ticks.
 --
 -- See Note [Leashing attacks]
-prop_leashingAttackTimeLimited :: Property
-prop_leashingAttackTimeLimited = runConformanceTest @TestBlock test_leashingAttackTimeLimited
-
 test_leashingAttackTimeLimited :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
@@ -373,9 +367,6 @@ headCallStack = \case
 
 -- | Test that enabling the LoE causes the selection to remain at
 -- the first fork intersection (keeping the immutable tip honest).
-prop_loeStalling :: Property
-prop_loeStalling = runConformanceTest @TestBlock test_loeStalling
-
 test_loeStalling :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
@@ -421,9 +412,6 @@ test_loeStalling =
 -- is greater than 11 seconds, and restarts it while only preserving the immutable DB after advancing the time.
 --
 -- This ensures that a user may shut down their machine while syncing without additional vulnerabilities.
-prop_downtime :: Property
-prop_downtime = runConformanceTest @TestBlock test_downtime
-
 test_downtime ::
   ( AF.HasHeader blk
   , GetHeader blk
@@ -461,15 +449,14 @@ test_downtime =
       , pgpDowntime = DowntimeWithSecurityParam (gtSecurityParam gt)
       }
 
+
 -- | Test that the block fetch leashing attack does not delay the immutable tip.
 -- This leashing attack consists in having adversarial peers that behave
 -- honestly when it comes to ChainSync but refuse to send blocks. A proper node
 -- under test should detect those behaviours as adversarial and find a way to
 -- make progress.
-prop_blockFetchLeashingAttack :: Property
-prop_blockFetchLeashingAttack = runConformanceTest @TestBlock test_blockFetchLeashingAttack
-
-
+--
+-- See Note [Leashing attacks]
 test_blockFetchLeashingAttack :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -247,7 +247,6 @@ test_leashingAttackStalling =
     shrinkPeerSchedules
 
     theProperty
-
   where
     -- | Produces schedules that might cause the node under test to stall.
     --
@@ -301,7 +300,6 @@ test_leashingAttackTimeLimited =
     shrinkPeerSchedules
 
     theProperty
-
   where
     -- | A schedule which doesn't run past the last event of the honest peer
     genTimeLimitedSchedule :: GenesisTest blk () -> QC.Gen (PointSchedule blk)
@@ -443,7 +441,6 @@ test_downtime =
         ]) $
         theProperty genesisTest stateView
     )
-
   where
     pointsGeneratorParams gt = PointsGeneratorParams
       { pgpExtraHonestPeers = fromIntegral (gtExtraHonestPeers gt)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -13,7 +13,7 @@
 -- other tests cases (eg. long range attack), the schedules are not particularly
 -- biased towards a specific situation.
 module Test.Consensus.Genesis.Tests.Uniform (
-    Test
+    TestKey
   , genUniformSchedulePoints
   , testSuite
   ) where
@@ -61,29 +61,30 @@ import           Text.Printf (printf)
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (* 10)
+adjustDesiredPasses :: Int -> Int
+adjustDesiredPasses = (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-testMaxSize :: Int -> Int
-testMaxSize = (`div` 5)
+adjustTestMaxSize :: Int -> Int
+adjustTestMaxSize = (`div` 5)
 
-data Test = BlockFetchLeashingAttack
-          | Downtime
-          | LeashingAttackStalling
-          | LeashingAttackTimeLimited
-          | LOEStalling
-          | ServeAdversarialBranches
-          deriving stock (Eq, Show, Ord, Generic)
-          deriving (Universe, Finite) via (GenericUniverse Test)
+-- | Each value of this type uniquely corresponds to a test defined in this module.
+data TestKey = BlockFetchLeashingAttack
+             | Downtime
+             | LeashingAttackStalling
+             | LeashingAttackTimeLimited
+             | LOEStalling
+             | ServeAdversarialBranches
+  deriving stock (Eq, Show, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "uniform" $ newTestSuite $ \case
     BlockFetchLeashingAttack -> test_blockFetchLeashingAttack
     Downtime -> test_downtime
@@ -163,7 +164,7 @@ test_serveAdversarialBranches ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_serveAdversarialBranches =
-  mkConformanceTest "serve adversarial branches" desiredPasses testMaxSize
+  mkConformanceTest "serve adversarial branches" adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
@@ -231,7 +232,7 @@ test_leashingAttackStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackStalling =
-  mkConformanceTest "stalling leashing attack" desiredPasses testMaxSize
+  mkConformanceTest "stalling leashing attack" adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
@@ -285,7 +286,7 @@ test_leashingAttackTimeLimited :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackTimeLimited =
-  mkConformanceTest "time limited leashing attack" desiredPasses testMaxSize
+  mkConformanceTest "time limited leashing attack" adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
@@ -374,7 +375,7 @@ test_loeStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_loeStalling =
-  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" desiredPasses testMaxSize
+  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" adjustDesiredPasses adjustTestMaxSize
 
     (do gt <- genChains (QC.choose (1, 4))
                 `enrichedWith`
@@ -419,7 +420,7 @@ test_downtime ::
   , Ord blk
   ) => ConformanceTest blk
 test_downtime =
-  mkConformanceTest "the node is shut down and restarted after some time" desiredPasses (testMaxSize . const 10)
+  mkConformanceTest "the node is shut down and restarted after some time" adjustDesiredPasses (adjustTestMaxSize . const 10)
 
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
@@ -464,7 +465,7 @@ test_blockFetchLeashingAttack :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_blockFetchLeashingAttack =
-  mkConformanceTest "block fetch leashing attack" desiredPasses testMaxSize
+  mkConformanceTest "block fetch leashing attack" adjustDesiredPasses adjustTestMaxSize
 
     (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -1,13 +1,43 @@
-module Test.Consensus.PeerSimulator.Tests (tests) where
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 
+module Test.Consensus.PeerSimulator.Tests (
+    testSuite
+  , tests
+  ) where
+
+import           Ouroboros.Consensus.Block.Abstract (HasHeader, Header,
+                     HeaderHash)
+import           Ouroboros.Consensus.Util.Condense (Condense)
+import           Test.Consensus.Genesis.Setup
+import           Test.Consensus.Genesis.TestSuite
 import qualified Test.Consensus.PeerSimulator.Tests.LinkedThreads as LinkedThreads
 import qualified Test.Consensus.PeerSimulator.Tests.Rollback as Rollback
 import qualified Test.Consensus.PeerSimulator.Tests.Timeouts as Timeouts
 import           Test.Tasty
+import           Test.Util.TestBlock (TestBlock)
 
 tests :: TestTree
-tests = testGroup "PeerSimulator" [
-    Rollback.tests,
-    Timeouts.tests,
-    LinkedThreads.tests
-  ]
+tests = testGroup "PeerSimulator" $ toTestTree @TestBlock testSuite
+
+data Test = LinkedThreads LinkedThreads.Test
+          | Rollback Rollback.Test
+          | Timeouts Timeouts.Test
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse Test
+
+testSuite ::
+  ( IssueTestBlock blk
+  , HasHeader blk
+  , HasHeader (Header blk)
+  , Condense (HeaderHash blk)
+  , Condense (Header blk)
+  , Eq blk
+  ) => TestSuite blk Test
+testSuite = mkTestSuite $ \case
+  LinkedThreads t -> at LinkedThreads.testSuite t
+  Rollback t -> at Rollback.testSuite t
+  Timeouts t -> at Timeouts.testSuite t

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -5,7 +5,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Consensus.PeerSimulator.Tests (
-    testSuite
+    SmokeTestKey
+  , testSuite
   , tests
   ) where
 
@@ -23,11 +24,12 @@ import           Test.Util.TestBlock (TestBlock)
 tests :: TestTree
 tests = testGroup "PeerSimulator" $ toTestTree @TestBlock testSuite
 
-data Test = LinkedThreads LinkedThreads.Test
-          | Rollback Rollback.Test
-          | Timeouts Timeouts.Test
+-- | Each value of this type uniquely corresponds to a basic functionality test.
+data SmokeTestKey = LinkedThreads LinkedThreads.TestKey
+                  | Rollback Rollback.TestKey
+                  | Timeouts Timeouts.TestKey
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse SmokeTestKey
 
 testSuite ::
   ( IssueTestBlock blk
@@ -36,7 +38,7 @@ testSuite ::
   , Condense (HeaderHash blk)
   , Condense (Header blk)
   , Eq blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk SmokeTestKey
 testSuite = mkTestSuite $ \case
   LinkedThreads t -> at LinkedThreads.testSuite t
   Rollback t -> at Rollback.testSuite t

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -42,7 +42,7 @@ testSuite ::
   , AF.HasHeader blk
   , Eq blk
   ) => TestSuite blk TestKey
-testSuite = group "ChainSync kill BlockFetch" . newTestSuite $ \case
+testSuite = group "ChainSync kills BlockFetch" . newTestSuite $ \case
   ChainSyncKillsBlockFetch -> test_chainSyncKillsBlockFetch
 
 -- | Check that when the scheduled ChainSync server gets killed, it takes the
@@ -64,7 +64,7 @@ test_chainSyncKillsBlockFetch =
     defaultSchedulerConfig {scEnableChainSyncTimeouts = True}
 
     -- No shrinking because the schedule is tiny and hand-crafted
-    (\_ _ -> [])
+    mempty
 
     ( \_ stateView@StateView {svTipBlock} ->
         svTipBlock == Nothing

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -8,7 +8,7 @@
 -- such that if one gets disconnected, then so does the other. This module
 -- contains a collection of smoke tests to make sure of that.
 module Test.Consensus.PeerSimulator.Tests.LinkedThreads (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -33,15 +33,15 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleHeaderPoint,
                      scheduleTipPoint)
 import           Test.Util.Orphans.IOLike ()
 
-data Test = ChainSyncKillsBlockFetch
+data TestKey = ChainSyncKillsBlockFetch
   deriving (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , Eq blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "ChainSync kill BlockFetch" . newTestSuite $ \case
   ChainSyncKillsBlockFetch -> test_chainSyncKillsBlockFetch
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (
-    test_cannotRollback
-  , test_rollback
-  , tests
+    Test
+  , testSuite
   ) where
 
 import           Cardano.Ledger.BaseTypes (unNonZero)
@@ -24,6 +24,7 @@ import           Test.Consensus.Genesis.Setup
 import           Test.Consensus.Genesis.Setup.Classifiers
                      (Classifiers (allAdversariesKPlus1InForecast),
                      allAdversariesForecastable, classifiers)
+import           Test.Consensus.Genesis.TestSuite
 import           Test.Consensus.PeerSimulator.Run (defaultSchedulerConfig)
 import           Test.Consensus.PeerSimulator.StateView
 import           Test.Consensus.PointSchedule
@@ -31,28 +32,30 @@ import           Test.Consensus.PointSchedule.Peers (peersOnlyHonest)
 import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..),
                      scheduleBlockPoint, scheduleHeaderPoint, scheduleTipPoint)
 import           Test.QuickCheck
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
-import           Test.Util.TestBlock (TestBlock)
 
 -- | Default adjustment of required property test passes.
 -- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 2)
 
-tests :: TestTree
-tests = testGroup "rollback"
-  [ testProperty "can rollback" prop_rollback
-  , testProperty "cannot rollback" prop_cannotRollback
-  ]
+data Test = CanRollback | WontRollback
+  deriving stock (Eq, Ord, Generic)
+  deriving (Universe, Finite) via GenericUniverse Test
 
--- | @prop_rollback@ tests that the selection of the node under test
+testSuite ::
+  ( IssueTestBlock blk
+  , AF.HasHeader blk
+  , AF.HasHeader (Header blk)
+  , Eq blk
+  ) => TestSuite blk Test
+testSuite = group "rollback" . newTestSuite $ \case
+  CanRollback -> test_rollback
+  WontRollback -> test_cannotRollback
+
+-- | @test_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
-prop_rollback :: Property
-prop_rollback = runConformanceTest @TestBlock test_rollback
-
 test_rollback ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
@@ -78,12 +81,9 @@ test_rollback =
 
     (\test -> not . hashOnTrunk (gtBlockTree test) . AF.headHash . svSelectedChain)
 
--- @prop_cannotRollback@ tests that the selection of the node under test *does
+-- @test_cannotRollback@ tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
 -- blocks before the current selection.
-prop_cannotRollback :: Property
-prop_cannotRollback = runConformanceTest @TestBlock test_cannotRollback
-
 test_cannotRollback ::
   ( IssueTestBlock blk
   , AF.HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -36,6 +36,8 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock (TestBlock)
 
+-- | Default adjustment of required property test passes.
+-- Can be set individually on each test definition.
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 2)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.PeerSimulator.Tests.Rollback (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -39,19 +39,19 @@ import           Test.Util.Orphans.IOLike ()
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 2)
 
-data Test = CanRollback | WontRollback
+data TestKey = CanRollback | CannotRollback
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , AF.HasHeader (Header blk)
   , Eq blk
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "rollback" . newTestSuite $ \case
   CanRollback -> test_rollback
-  WontRollback -> test_cannotRollback
+  CannotRollback -> test_cannotRollback
 
 -- | @test_rollback@ tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -53,7 +53,7 @@ testSuite = group "rollback" . newTestSuite $ \case
   CanRollback -> test_rollback
   CannotRollback -> test_cannotRollback
 
--- | @test_rollback@ tests that the selection of the node under test
+-- | Tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
 test_rollback ::
@@ -77,11 +77,11 @@ test_rollback =
     defaultSchedulerConfig
 
     -- No shrinking because the schedule is tiny and hand-crafted
-    (\_ _ -> [])
+    mempty
 
     (\test -> not . hashOnTrunk (gtBlockTree test) . AF.headHash . svSelectedChain)
 
--- @test_cannotRollback@ tests that the selection of the node under test *does
+-- | Tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
 -- blocks before the current selection.
 test_cannotRollback ::
@@ -98,7 +98,7 @@ test_cannotRollback =
     defaultSchedulerConfig
 
     -- No shrinking because the schedule is tiny and hand-crafted
-    (\_ _ -> [])
+    mempty
 
     (\test -> hashOnTrunk (gtBlockTree test) . AF.headHash . svSelectedChain)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ViewPatterns #-}
 
 module Test.Consensus.PeerSimulator.Tests.Timeouts (
-    Test
+    TestKey
   , testSuite
   ) where
 
@@ -38,9 +38,10 @@ import           Test.Util.Orphans.IOLike ()
 desiredPasses :: Int -> Int
 desiredPasses = (`div` 10)
 
-data Test = Timeouts !Bool
+data TestKey = DoesTimeout
+             | DoesNotTimeout
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse Test
+  deriving (Universe, Finite) via GenericUniverse TestKey
 
 testSuite ::
   ( IssueTestBlock blk
@@ -48,10 +49,10 @@ testSuite ::
   , AF.HasHeader (Header blk)
   , Condense (HeaderHash blk)
   , Condense (Header blk)
-  ) => TestSuite blk Test
+  ) => TestSuite blk TestKey
 testSuite = group "timeouts" . newTestSuite $ \case
-  Timeouts True -> test_timeouts "does time out" True
-  Timeouts False -> test_timeouts "does not time out" False
+  DoesTimeout -> test_timeouts "does time out" True
+  DoesNotTimeout -> test_timeouts "does not time out" False
 
 test_timeouts ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -73,7 +73,7 @@ test_timeouts description mustTimeout =
     -- Here we can't shrink because we exploit the properties of the point schedule to wait
     -- at the end of the test for the adversaries to get disconnected, by adding an extra point.
     -- If this point gets removed by the shrinker, we lose that property and the test becomes useless.
-    (\_ _ -> [])
+    mempty
 
     (\_ stateView ->
       case exceptionsByComponent ChainSyncClient stateView of


### PR DESCRIPTION
# Description

Closes tweag/cardano-conformance-testing-of-consensus#75

This PR arranges all `ConformanceTest`s in `TestSuite`s, a data structure introduced in #28 with the goal of eventually export them in a separate package for the conformance testing harness; it was in #30 that all tests that dependended on the `forAllGenesisTest` mechanism where reified into `ConformanceTest` values. All this changes are essentially a refactor of the `consensus-test` suite, so the semantics of the tests in place remain unchanged.

A new data type is introduced for each module as a `key` for the corresponding `TestSuite`. This means that a new constructor must be introduced for each new test. These data types are agregated into other data types to reify the nested grouping of tasty `TestTree`s. The `Finite` constraint needed for their construction (via `newTestSuite` and `mkTestSuite`) ensures that each `TestSuite` is a total map.
