### PR TITLE
Implement `SmallKey` class and generic instance

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -244,6 +244,7 @@ library unstable-consensus-conformance-testlib
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.Genesis.TestSuite
     Test.Consensus.Genesis.TestSuite.SmallKey
+    Test.Consensus.Genesis.TestSuite.SmallKey.Tests
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B

--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -243,6 +243,7 @@ library unstable-consensus-conformance-testlib
     Test.Consensus.Genesis.Tests.LongRangeAttack
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.Genesis.TestSuite
+    Test.Consensus.Genesis.TestSuite.SmallKey
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B
@@ -333,7 +334,6 @@ library unstable-consensus-conformance-testlib
     time,
     tree-diff,
     typed-protocols,
-    universe-base,
     unstable-diffusion-testlib,
     vector,
 

--- a/ouroboros-consensus-diffusion/test/consensus-test-main/Main.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test-main/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Test.Consensus.BlockTree.Tests (tests)
 import qualified Test.Consensus.Genesis.Tests (tests)
+import qualified Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests)
 import qualified Test.Consensus.GSM (tests)
 import qualified Test.Consensus.HardFork.Combinator (tests)
 import qualified Test.Consensus.Node (tests)
@@ -35,4 +36,5 @@ tests =
     , Test.Consensus.PointSchedule.Tests.tests
     , Test.Consensus.BlockTree.Tests.tests
     , Test.Consensus.Serialize.Tests.tests
+    , Test.Consensus.Genesis.TestSuite.SmallKey.Tests.tests
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -- | A 'TestSuite' data structure for quick access to 'ConformanceTest' values.
 -- It encodes a hierarchical nested structure allowing it to compile into a
@@ -14,11 +12,14 @@
 -- It's purpose is interfacing between property test execution and the
 -- conformance testing harness.
 module Test.Consensus.Genesis.TestSuite (
-    Finite
-  , Generic
-  , GenericUniverse (..)
+    -- * 'SmallKey' class
+    --
+    -- $deriveSmallkey
+    Generic
+  , Generically (..)
+  , SmallKey
+    -- * 'TestSuite' API
   , TestSuite
-  , Universe
   , at
   , getTest
   , group
@@ -27,16 +28,13 @@ module Test.Consensus.Genesis.TestSuite (
   , toTestTree
   ) where
 
-import           Data.Coerce (coerce)
 import           Data.Foldable (toList)
 import           Data.Map.Monoidal (MonoidalMap)
 import qualified Data.Map.Monoidal as MMap
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Monoid (Endo (..))
-import           Data.Universe.Class (Finite (..), Universe (..))
-import           Data.Universe.Generic (GUniverse, universeGeneric)
-import           GHC.Generics (Generic (Rep), Generically (..))
+import           GHC.Generics (Generic, Generically (..))
 import           Ouroboros.Consensus.Block (BlockSupportsDiffusionPipelining,
                      ConvertRawHash, Header)
 import           Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
@@ -52,20 +50,12 @@ import           Ouroboros.Consensus.Util.Condense (Condense, CondenseList)
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
 import           Test.Consensus.Genesis.Setup (ConformanceTest (..),
                      runConformanceTest)
+import           Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (..))
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Util.TersePrinting (Terse)
-
--- | A data type with generically defined  'Universe' and 'Finite' instances.
--- Intended to derive said instances (via @DerivingVia@ extension) for 'TestSuite' keys.
-newtype GenericUniverse a = GenericUniverse a
-
-instance (Generic a, GUniverse (Rep a)) => Universe (GenericUniverse a) where
-  universe = coerce $ universeGeneric @a
-
-instance (Generic a, GUniverse (Rep a)) => Finite (GenericUniverse a)
 
 data TestSuiteData blk = TestSuiteData
   { -- | A prefix representing a path through the test group tree.
@@ -80,26 +70,23 @@ data TestSuiteData blk = TestSuiteData
 -- | A @TestSuite blk key@ contains one 'ConformanceTest'@blk@ for each @key@.
 newtype TestSuite blk key = TestSuite (Map key (TestSuiteData blk))
 
--- NOTE: [GenericFinite]
--- 'Universe' and 'Finite' constraints on @key@ are meant to be derived
--- generically by means of the 'GenericUniverse' wrapper.
--- Using a @key@ having a constructor with a big finite type parameter
--- (such as 'Int') should be avoided as this is likely to flood the memory.
--- TODO: Reimplement 'Finite' to prevent instances of big finite types.
-
 -- | Build a 'TestSuite' by looking 'at' 'TestSuiteData', allowing to preserve the
 -- hierarchical structure of a previously constructed 'TestSuite'.
--- See NOTE [GenericFinite]
-mkTestSuite :: (Ord key, Finite key)
+--
+-- See NOTE [DeriveSmallKey]
+--
+mkTestSuite :: (Ord key, SmallKey key)
                  => (key -> TestSuiteData blk)
                  -> TestSuite blk key
 mkTestSuite toData =
-  TestSuite . Map.fromList . fmap ((,) <$> id <*> toData) $ universeF
+  TestSuite . Map.fromList . fmap ((,) <$> id <*> toData) $ allKeys
 
 -- | Build a 'TestSuite' from a function mapping a @key@ type to 'ConformanceTest'
 -- making all tests top-level.
--- See NOTE [GenericFinite]
-newTestSuite :: (Ord key, Finite key)
+--
+-- See NOTE [DeriveSmallKey]
+--
+newTestSuite :: (Ord key, SmallKey key)
             => (key -> ConformanceTest blk)
             -> TestSuite blk key
 newTestSuite toConformanceTest =
@@ -107,6 +94,22 @@ newTestSuite toConformanceTest =
                                , tsTest = toConformanceTest k
                                }
    in mkTestSuite toData
+
+-- $deriveSmallKey
+--
+-- NOTE [DeriveSmallKey]
+-- The 'SmallKey' constraint on 'TestSuite' @key@s is meant to be derived
+-- 'via Generically' only; because of this, some its class methods are not
+-- exported to prevent users of this class from instantiating it for large
+-- finite data types (such as 'Int' or 'Word32'), which are likely to flood the
+-- memory when constructing a 'TestSuite' because 'allKeys' are used
+-- operationally to drive its exhaustive construction. As precaution, product
+-- and syntactically-recursive types are forbidden from instanciating it and some
+-- large types have been explicitly black-listed.
+--
+-- The rationale behind the enforced restrictions is that @keys@ are expected
+-- to be constructed primarily from user defined sum types of nullary
+-- constructors corresponding to single test properties.
 
 at :: Ord key => TestSuite blk key -> key ->  TestSuiteData blk
 at (TestSuite m) k = case Map.lookup k m of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
@@ -15,9 +15,11 @@
 module Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (allKeys)) where
 
 import           Data.Kind
+import           Data.Proxy
 import           Data.Word
 import           GHC.Generics
 import           GHC.TypeError
+import           Type.Reflection
 
 -- | Creating an instance of this class is a declaration that the type has a
 -- /small/ finite number of values and that 'allKeys' constains them all.
@@ -88,7 +90,7 @@ instance (GSmallKey f, GSmallKey g) => GSmallKey (f :+: g) where
 instance TypeError ('Text "Product types are not allowed "
                     ':<>: 'Text "to have a SmallKey instance" )
   => GSmallKey (f :*: g) where
-  gAllKeys = error "unreachable"
+  gAllKeys = error "unreachable: product type"
 
 instance GSmallKey f => GSmallKey (M1 i c f) where
   gAllKeys = fmap M1 gAllKeys
@@ -111,23 +113,27 @@ type family NoSmallKey ty :: Constraint where
     TypeError ('ShowType ty ':<>: 'Text " doesn't have a SmallKey instance"
                ':$$: 'Text "because it is too large for exhaustive construction")
 
+
+unreachableSK :: forall a. Typeable a => Proxy a -> String
+unreachableSK _ = "unreachable: NoSmallKey " <> show (typeRep @a)
+
 instance NoSmallKey Integer  => SmallKey Integer where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Integer)
 
 instance NoSmallKey Int => SmallKey Int where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Int)
 
 instance NoSmallKey Word => SmallKey Word where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Word)
 
 instance NoSmallKey Word16 => SmallKey Word16 where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Word16)
 
 instance NoSmallKey Word32 => SmallKey Word32 where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Word32)
 
 instance NoSmallKey Word64 => SmallKey Word64 where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Word64)
 
 instance NoSmallKey Char => SmallKey Char where
-  allKeys = error "unreachable"
+  allKeys = error $ unreachableSK (Proxy :: Proxy Char)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoStarIsType #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Internal module defining the 'SmallKey' utiliy class for 'TestSuite'
+-- construction. Exposed through `Test.Consensus.Genesis.TestSuite` re-exports.
+module Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (..)) where
+
+import           Data.Kind
+import           Data.Word
+import           GHC.Generics
+import           GHC.TypeLits
+
+-- | Creating an instance of this class is a declaration that the type has a
+-- /small/ finite number of values and that 'allKeys' constains them all.
+-- \"Small\" here is a safety requirement, meaning that it is feasible to
+-- drive an exhaustive construction from its values.
+--
+-- /Laws:/
+--
+-- @
+-- 'elem' x 'allKeys'                         -- Any inhabitant has a finite index
+-- 'length' ('filter' (== x) 'allKeys') == 1  -- Should terminate
+-- @
+--
+class SmallKey a where
+    allKeys :: [a]
+
+instance
+  ( Generic a
+  , AssertNotRecursive a (Rep a)
+  , GSmallKey (Rep a)
+  ) => SmallKey (Generically a) where
+  allKeys = fmap (Generically . to) $ gAllKeys @(Rep a)
+
+type family AssertNotRecursive (a :: Type) (f :: Type -> Type) :: Constraint where
+  -- Throw type error if a direct recursive occurrence of the data type is found
+  -- in its generic representation.
+  AssertNotRecursive a (Rec0 a) =
+    TypeError ( 'Text "Recursive data types are not allowed "
+                ':<>: 'Text "to have a SmallKey instance: " ':<>: 'ShowType a)
+
+  AssertNotRecursive _ (Rec0 _) = ()
+
+  AssertNotRecursive a (l :+: r) =
+    (AssertNotRecursive a l, AssertNotRecursive a r)
+
+  AssertNotRecursive a (l :*: r) =
+    (AssertNotRecursive a l, AssertNotRecursive a r)
+
+  AssertNotRecursive a (M1 _ _ f) =
+    AssertNotRecursive a f
+
+  AssertNotRecursive _ _ = ()
+
+-- * Generic instance of 'SmallKey'
+
+class GSmallKey f where
+  gAllKeys :: [f a]
+
+instance GSmallKey V1 where
+  gAllKeys = []
+
+instance GSmallKey U1 where
+  gAllKeys = [U1]
+
+instance (GSmallKey f, GSmallKey g) => GSmallKey (f :+: g) where
+  gAllKeys = fmap L1 gAllKeys <> fmap R1 gAllKeys
+
+instance TypeError ('Text "Product types are not allowed "
+                    ':<>: 'Text "to have a SmallKey instance" )
+  => GSmallKey (f :*: g) where
+  gAllKeys = error "unreachable"
+
+instance GSmallKey f => GSmallKey (M1 i c f) where
+  gAllKeys = fmap M1 gAllKeys
+
+instance SmallKey a => GSmallKey (K1 r a) where
+  gAllKeys = fmap K1 allKeys
+
+-- * Bundled instances
+
+instance SmallKey () where
+  allKeys = [()]
+
+instance SmallKey Bool where
+  allKeys = [False, True]
+
+-- * Black-listed instances of large types.
+
+type family NoSmallKey ty :: Constraint where
+  NoSmallKey ty =
+    TypeError ('ShowType ty ':<>: 'Text " doesn't have a SmallKey instance"
+               ':$$: 'Text "because it is too large for exhaustive construction")
+
+instance NoSmallKey Integer  => SmallKey Integer where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Int => SmallKey Int where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Word => SmallKey Word where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Word16 => SmallKey Word16 where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Word32 => SmallKey Word32 where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Word64 => SmallKey Word64 where
+  allKeys = error "unreachable"
+
+instance NoSmallKey Char => SmallKey Char where
+  allKeys = error "unreachable"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
@@ -12,12 +12,12 @@
 
 -- | Internal module defining the 'SmallKey' utiliy class for 'TestSuite'
 -- construction. Exposed through `Test.Consensus.Genesis.TestSuite` re-exports.
-module Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (..)) where
+module Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (allKeys)) where
 
 import           Data.Kind
 import           Data.Word
 import           GHC.Generics
-import           GHC.TypeLits
+import           GHC.TypeError
 
 -- | Creating an instance of this class is a declaration that the type has a
 -- /small/ finite number of values and that 'allKeys' constains them all.
@@ -40,6 +40,16 @@ instance
   , GSmallKey (Rep a)
   ) => SmallKey (Generically a) where
   allKeys = fmap (Generically . to) $ gAllKeys @(Rep a)
+
+--------------------------------------------------------------------------------
+-- TODO [Blacklist]
+--
+-- If @base ^>=4.19.0.0@, then `GHC.TypeError.Unsatisfiable` +
+-- `GHC.TypeError.unsatisfiable` can be used to black-list types instead of
+-- 'TypeError' + 'error', allowing a finer triggering of the error.
+--
+-- See https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0433-unsatisfiable.rst
+--------------------------------------------------------------------------------
 
 type family AssertNotRecursive (a :: Type) (f :: Type -> Type) :: Constraint where
   -- Throw type error if a direct recursive occurrence of the data type is found

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- NOTE: This tests defer the type errors that would other wise prevent
+-- the following 'allKeys' instances from being called (or defined).
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+{-# OPTIONS_GHC -Wno-deferred-type-errors #-}
+
+module Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests) where
+
+import           Control.DeepSeq (NFData)
+import           Data.List (permutations)
+import           GHC.Generics
+import           Test.Consensus.Genesis.TestSuite.SmallKey
+import           Test.ShouldNotTypecheck (shouldNotTypecheck)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+data SimpleInfiniteType = Nil | More SimpleInfiniteType
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass NFData
+  deriving SmallKey via Generically SimpleInfiniteType
+
+data UnitSumType = L () | R ()
+  deriving stock (Eq, Ord, Generic)
+  deriving SmallKey via Generically UnitSumType
+
+data UnitProductType = P () ()
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass NFData
+  deriving SmallKey via Generically UnitProductType
+
+data IntUnaryType = U Int
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass NFData
+  deriving SmallKey via Generically IntUnaryType
+
+tests :: TestTree
+tests = testGroup "SmallKey"
+  [ testCase "A minimal sum type instance" $
+      assertBool "allKeys must be a permutation of the list of all values" $
+        elem (allKeys @UnitSumType) $ permutations [L (), R ()]
+  , testCase "A minimal product type does not typecheck" $
+      shouldNotTypecheck $ allKeys @UnitProductType
+  , testCase "A minimal unary type with black-listed Int argument does not typecheck" $
+      shouldNotTypecheck $ allKeys @IntUnaryType
+  , testCase "A simple recursive infinite type does not typecheck" $
+      shouldNotTypecheck $ allKeys @SimpleInfiniteType
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -18,18 +17,12 @@
 
 module Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests) where
 
-import           Control.DeepSeq (NFData)
-import           Data.List (permutations)
+import           Control.Exception
+import           Data.List (isInfixOf, permutations)
 import           GHC.Generics
 import           Test.Consensus.Genesis.TestSuite.SmallKey
-import           Test.ShouldNotTypecheck (shouldNotTypecheck)
 import           Test.Tasty
 import           Test.Tasty.HUnit
-
-data SimpleInfiniteType = Nil | More SimpleInfiniteType
-  deriving stock (Eq, Ord, Generic)
-  deriving anyclass NFData
-  deriving SmallKey via Generically SimpleInfiniteType
 
 data UnitSumType = L () | R ()
   deriving stock (Eq, Ord, Generic)
@@ -37,23 +30,50 @@ data UnitSumType = L () | R ()
 
 data UnitProductType = P () ()
   deriving stock (Eq, Ord, Generic)
-  deriving anyclass NFData
   deriving SmallKey via Generically UnitProductType
 
 data IntUnaryType = U Int
   deriving stock (Eq, Ord, Generic)
-  deriving anyclass NFData
   deriving SmallKey via Generically IntUnaryType
 
+-- | Contains a unit test for the correct derivation of a simple instance and
+-- one corresponding to each black-listing strategy:
+--
+-- 1. A type with a product on its generic representation.
+-- 2. A type with a explicitly black-listed field.
+--
+-- NOTE: These tests depend on @-fdefer-type-errors@ to run.
+--
+-- TODO: Once the use of 'TypeError' changes to 'Unsatisfiable' in 'SmallKey' it
+-- should be possible to 'assertError' the actual type error, and even
+-- test a failing instance for
+--
+-- @
+-- data SimpleInfiniteType = Nil | More SimpleInfiniteType
+--   deriving stock (Eq, Ord, Generic)
+--   deriving SmallKey via Generically SimpleInfiniteType
+-- @
+--
+-- as we could avoid the evaluation of `allKeys` altogether.
+-- See TODO [BlackList].
+--
 tests :: TestTree
 tests = testGroup "SmallKey"
   [ testCase "A minimal sum type instance" $
       assertBool "allKeys must be a permutation of the list of all values" $
         elem (allKeys @UnitSumType) $ permutations [L (), R ()]
-  , testCase "A minimal product type does not typecheck" $
-      shouldNotTypecheck $ allKeys @UnitProductType
-  , testCase "A minimal unary type with black-listed Int argument does not typecheck" $
-      shouldNotTypecheck $ allKeys @IntUnaryType
-  , testCase "A simple recursive infinite type does not typecheck" $
-      shouldNotTypecheck $ allKeys @SimpleInfiniteType
+  , testCase "A minimal product type instance is forbidden" $
+      assertError "unreachable" $ allKeys @UnitProductType
+  , testCase "A minimal unary type instance with black-listed Int argument is forbidden" $
+      assertError "unreachable" $ allKeys @IntUnaryType
   ]
+
+assertError :: String -> a -> Assertion
+assertError expected val = do
+  result <- try @ErrorCall (evaluate val)
+  case result of
+    Left (ErrorCall msg)
+      | expected `isInfixOf` msg -> pure ()
+      | otherwise -> assertFailure $ "Unexpected error message:\n" <> msg
+    Right _ ->
+      assertFailure "Expected a type error, but computation succeeded"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
@@ -63,9 +63,9 @@ tests = testGroup "SmallKey"
       assertBool "allKeys must be a permutation of the list of all values" $
         elem (allKeys @UnitSumType) $ permutations [L (), R ()]
   , testCase "A minimal product type instance is forbidden" $
-      assertError "unreachable" $ allKeys @UnitProductType
+      assertError "unreachable: product type" $ allKeys @UnitProductType
   , testCase "A minimal unary type instance with black-listed Int argument is forbidden" $
-      assertError "unreachable" $ allKeys @IntUnaryType
+      assertError "unreachable: NoSmallKey Int" $ allKeys @IntUnaryType
   ]
 
 assertError :: String -> a -> Assertion

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -36,7 +36,7 @@ data GenesisTestKey = Uniform !Uniform.TestKey
              | LoE !LoE.TestKey
              | LoP !LoP.TestKey
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse GenesisTestKey
+  deriving SmallKey via Generically GenesisTestKey
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -51,9 +51,12 @@ adjustTestMaxSize :: Int -> Int
 adjustTestMaxSize = (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
-data TestKey = ChainSyncJump !WithAdversariesFlag !NumHonestSchedulesFlag
+data TestKey = WithNoAdversariesAndOneScheduleForAllPeers
+             | WithNoAdversariesAndOneSchedulePerHonestPeer
+             | WithAdversariesAndOneScheduleForAllPeers
+             | WithAdversariesAndOneSchedulePerHonestPeer
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( HasHeader blk
@@ -64,25 +67,22 @@ testSuite ::
   , Eq (Header blk)
   ) => TestSuite blk TestKey
 testSuite = group "CSJ" $ newTestSuite $ \case
-  ChainSyncJump NoAdversaries OneScheduleForAllPeers ->
+  WithNoAdversariesAndOneScheduleForAllPeers ->
     test_csj "adversary free: honest peers are synchronised" NoAdversaries OneScheduleForAllPeers
-  ChainSyncJump NoAdversaries OneSchedulePerHonestPeer ->
+  WithNoAdversariesAndOneSchedulePerHonestPeer ->
     test_csj "adversary free: peers do their own thing" NoAdversaries OneSchedulePerHonestPeer
-  ChainSyncJump WithAdversaries OneScheduleForAllPeers ->
+  WithAdversariesAndOneScheduleForAllPeers ->
     test_csj "with some adversaries: honest peers are synchronised" WithAdversaries OneScheduleForAllPeers
-  ChainSyncJump WithAdversaries OneSchedulePerHonestPeer ->
+  WithAdversariesAndOneSchedulePerHonestPeer ->
     test_csj "with some adversaries: honest peers do their own thing" WithAdversaries OneSchedulePerHonestPeer
 
 -- | A flag to indicate if properties are tested with adversarial peers
 data WithAdversariesFlag = NoAdversaries | WithAdversaries
-  deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via (GenericUniverse WithAdversariesFlag)
+  deriving stock Eq
 
 -- | A flag to indicate if properties are tested using the same schedule for the
 -- honest peers, or if each peer should used its own schedule.
 data NumHonestSchedulesFlag = OneScheduleForAllPeers | OneSchedulePerHonestPeer
-  deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via (GenericUniverse NumHonestSchedulesFlag)
 
 -- | Test of ChainSync Jumping (CSJ).
 --

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -88,7 +88,7 @@ adjustTestMaxSize = (`div` 5)
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = TriggersChainSelection
   deriving stock (Eq,Ord,Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -47,7 +47,7 @@ adjustTestMaxSize = (`div` 5)
 data TestKey = AdversaryDoesNotHitTimeouts
              | AdversaryHitsTimeouts
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -58,7 +58,7 @@ data TestKey = WaitJustEnoughUntilEmpty
              | DelayAttackSucceeds
              | DelayAttackFails
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -32,8 +32,8 @@ adjustDesiredPasses = (`div` 10)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = LongRangeAttack
-  deriving stock (Eq,Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving stock (Eq, Ord, Generic)
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
    (HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -80,7 +80,7 @@ data TestKey = BlockFetchLeashingAttack
              | LOEStalling
              | ServeAdversarialBranches
   deriving stock (Eq, Show, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( AF.HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -29,7 +29,7 @@ data SmokeTestKey = LinkedThreads LinkedThreads.TestKey
                   | Rollback Rollback.TestKey
                   | Timeouts Timeouts.TestKey
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse SmokeTestKey
+  deriving SmallKey via Generically SmokeTestKey
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -35,7 +35,7 @@ import           Test.Util.Orphans.IOLike ()
 
 data TestKey = ChainSyncKillsBlockFetch
   deriving (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -41,7 +41,7 @@ desiredPasses = (`div` 2)
 
 data TestKey = CanRollback | CannotRollback
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -41,7 +41,7 @@ desiredPasses = (`div` 10)
 data TestKey = DoesTimeout
              | DoesNotTimeout
   deriving stock (Eq, Ord, Generic)
-  deriving (Universe, Finite) via GenericUniverse TestKey
+  deriving SmallKey via Generically TestKey
 
 testSuite ::
   ( IssueTestBlock blk


### PR DESCRIPTION
Closes https://github.com/tweag/cardano-conformance-testing-of-consensus/issues/98

This PR gets rid of the `universe-base` dependency by defining the `SmallKey` type class to supersede `Finite`, which is an essential constraint needed for the construction of a `TestSuite`.