### PR TITLE
Implement helpers to transform quickcheck test run default values

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -58,10 +58,14 @@ import           Test.Consensus.PeerSimulator.Trace (traceLinesWith,
 import           Test.Consensus.PointSchedule
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.QuickCheck
+import           Test.Tasty (TestTree)
+import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.QuickCheck (forAllGenRunShrinkCheck)
 import           Test.Util.TersePrinting (Terse)
 import           Test.Util.TestBlock (TestBlock)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
 import           Test.Util.Tracer (recordingTracerM)
 import           Text.Printf (printf)
 
@@ -182,34 +186,31 @@ runConformanceTest :: forall blk.
   , Terse blk
   , Condense (NodeState blk)
   ) =>
-  ConformanceTest blk -> Property
-runConformanceTest ConformanceTest {..} = idempotentIOProperty $ do
-  protocolInfoArgs <- getProtocolInfoArgs
-  pure $ forAllGenRunShrinkCheck ctGenerator (runGenesisTest protocolInfoArgs ctSchedulerConfig) shrinker' $ \genesisTest result ->
-    let cls = classifiers genesisTest
-        resCls = resultClassifiers genesisTest result
-        schCls = scheduleClassifiers genesisTest
-        stateView = rgtrStateView result
-     in classify (allAdversariesSelectable cls) "All adversaries have more than k blocks after intersection" $
-        classify (allAdversariesForecastable cls) "All adversaries have at least 1 forecastable block after intersection" $
-        classify (allAdversariesKPlus1InForecast cls) "All adversaries have k+1 blocks in forecast window after intersection" $
-        classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
-        classify (adversaryRollback schCls) "An adversary did a rollback" $
-        classify (honestRollback schCls) "The honest peer did a rollback" $
-        classify (allAdversariesEmpty schCls) "All adversaries have empty schedules" $
-        classify (allAdversariesTrivial schCls) "All adversaries have trivial schedules" $
-        tabulate "Adversaries killed by LoP" [printf "%.1f%%" $ adversariesKilledByLoP resCls] $
-        tabulate "Adversaries killed by GDD" [printf "%.1f%%" $ adversariesKilledByGDD resCls] $
-        tabulate "Adversaries killed by Timeout" [printf "%.1f%%" $ adversariesKilledByTimeout resCls] $
-        tabulate "Surviving adversaries" [printf "%.1f%%" $ adversariesSurvived resCls] $
-        counterexample (rgtrTrace result) $
-        -- | TODO: Here we want to transform the default /max size/ and
-        -- /max success/ values instead of hard coding them to 100. We will be
-        -- implementing the necesary helpers (similar in spirit to
-        -- 'TestEnv.adjustQuickCheckMaxSize' and 'adjustQuickCheckTests'
-        -- respectively) in a follow up PR.
-        withMaxSize (ctMaxSize 100) . withMaxSuccess (ctDesiredPasses 100) $
-        ctProperty genesisTest stateView .&&. hasOnlyExpectedExceptions stateView
+  ConformanceTest blk -> TestTree
+runConformanceTest ConformanceTest {..} =
+  adjustQuickCheckTests ctDesiredPasses $
+  adjustQuickCheckMaxSize ctMaxSize $
+  QC.testProperty ctDescription $ idempotentIOProperty $ do
+    protocolInfoArgs <- getProtocolInfoArgs
+    pure $ forAllGenRunShrinkCheck ctGenerator (runGenesisTest protocolInfoArgs ctSchedulerConfig) shrinker' $ \genesisTest result ->
+      let cls = classifiers genesisTest
+          resCls = resultClassifiers genesisTest result
+          schCls = scheduleClassifiers genesisTest
+          stateView = rgtrStateView result
+      in classify (allAdversariesSelectable cls) "All adversaries have more than k blocks after intersection" $
+          classify (allAdversariesForecastable cls) "All adversaries have at least 1 forecastable block after intersection" $
+          classify (allAdversariesKPlus1InForecast cls) "All adversaries have k+1 blocks in forecast window after intersection" $
+          classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
+          classify (adversaryRollback schCls) "An adversary did a rollback" $
+          classify (honestRollback schCls) "The honest peer did a rollback" $
+          classify (allAdversariesEmpty schCls) "All adversaries have empty schedules" $
+          classify (allAdversariesTrivial schCls) "All adversaries have trivial schedules" $
+          tabulate "Adversaries killed by LoP" [printf "%.1f%%" $ adversariesKilledByLoP resCls] $
+          tabulate "Adversaries killed by GDD" [printf "%.1f%%" $ adversariesKilledByGDD resCls] $
+          tabulate "Adversaries killed by Timeout" [printf "%.1f%%" $ adversariesKilledByTimeout resCls] $
+          tabulate "Surviving adversaries" [printf "%.1f%%" $ adversariesSurvived resCls] $
+          counterexample (rgtrTrace result) $
+          ctProperty genesisTest stateView .&&. hasOnlyExpectedExceptions stateView
   where
     shrinker' gt = ctShrinker gt . rgtrStateView
     hasOnlyExpectedExceptions StateView{svPeerSimulatorResults} =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -28,6 +28,7 @@ module Test.Consensus.Genesis.TestSuite (
   ) where
 
 import           Data.Coerce (coerce)
+import           Data.Foldable (toList)
 import           Data.Map.Monoidal (MonoidalMap)
 import qualified Data.Map.Monoidal as MMap
 import           Data.Map.Strict (Map)
@@ -55,7 +56,6 @@ import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Tasty (TestTree, testGroup)
-import qualified Test.Tasty.QuickCheck as QC
 import           Test.Util.TersePrinting (Terse)
 
 -- | A data type with generically defined  'Universe' and 'Finite' instances.
@@ -140,14 +140,6 @@ mkTestTrie pfs t =
       leaf = TestTrie [t] mempty
   in appEndo (foldMap nest pfs) leaf
 
--- | Fold a list of prefixed tests into a 'TestTrie'.
---
--- Each input pair @([Prefix], TestTree)@ is interpreted as a path
--- in the trie, and the resulting trie merges common prefixes into
--- shared nodes.
-buildTrie :: [([String], TestTree)] -> TestTrie
-buildTrie = foldMap (uncurry mkTestTrie)
-
 -- | Fold a 'TestTrie' into a list of 'TestTree's by recursively
 -- rendering each trie node as a 'testGroup'.
 render :: TestTrie -> [TestTree]
@@ -156,32 +148,6 @@ render (TestTrie here children) =
     fmap
       (\(p,tt) -> testGroup p (render tt))
       (MMap.toList children)
-
--- | Produces a single-test 'TestTree', along with its containing
--- 'group' prefixes, out a 'TestSuiteData'.
-compileSingleTest ::
-  ( Condense (StateView blk)
-  , CondenseList (NodeState blk)
-  , ShowProxy blk
-  , ShowProxy (Header blk)
-  , ConfigSupportsNode blk
-  , LedgerSupportsProtocol blk
-  , SerialiseDiskConstraints blk
-  , BlockSupportsDiffusionPipelining blk
-  , InspectLedger blk
-  , HasHardForkHistory blk
-  , ConvertRawHash blk
-  , CanUpgradeLedgerTables (LedgerState blk)
-  , HasPointScheduleTestParams blk
-  , Eq (Header blk)
-  , Eq blk
-  , Terse blk
-  , Condense (NodeState blk)
-  ) =>
-  TestSuiteData blk -> ([String], TestTree)
-compileSingleTest (TestSuiteData {tsPrefix, tsTest}) =
-  let testName = ctDescription tsTest
-   in (tsPrefix, QC.testProperty testName (runConformanceTest tsTest))
 
 -- | Compile a 'TestSuite' into a list of tasty 'TestTree'.
 toTestTree ::
@@ -205,6 +171,6 @@ toTestTree ::
   ) =>
   TestSuite blk key -> [TestTree]
 toTestTree (TestSuite m) =
-  let tests = fmap snd $ Map.toList m
-      prefixedTests = fmap compileSingleTest tests
-   in render . buildTrie $ prefixedTests
+  render $ mconcat $ do
+    TestSuiteData {tsPrefix, tsTest} <- toList m
+    pure $ mkTestTrie tsPrefix $ runConformanceTest tsTest


### PR DESCRIPTION
This PR fixes https://github.com/tweag/cardano-conformance-testing-of-consensus/issues/92.

Rather than building a `Property` and then wrapping it into a `TestGroup` as a separate step, we just do that all at once; this ensures the testenv is necessarily updated.

I also inlined a few definitions as I went, since they were only ever used in a single place, and I think the code reads cleaner without the extra definitions lying around.