### PR TITLE
Edit haddock docs in Test.Consensus.PointSchedule.Peers

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -12,32 +12,39 @@
 -- represented opaquely by a 'PeerId'.
 
 module Test.Consensus.PointSchedule.Peers (
+    -- * 'Peer'
     Peer (..)
   , PeerId (..)
+  , enumerateAdversaries
+  , isAdversarialPeerId
+  , isHonestPeerId
+    -- * 'Peers'
   , Peers (..)
+    -- ** Constructors
+  , peersOnlyAdversary
+  , peersOnlyHonest
+    -- ** Combinators
+  , unionWithKey
+    -- ** Queries
   , adversarialPeers'
   , adversarialPeers''
-  , deletePeer
-  , enumerateAdversaries
-  , fromMap
-  , fromMap'
   , getPeer
   , getPeerIds
   , honestPeers'
   , honestPeers''
-  , isAdversarialPeerId
-  , isHonestPeerId
+    -- ** Modifiers
+  , deletePeer
+  , updatePeer
+    -- ** Conversions
+  , fromMap
+  , fromMap'
   , peers'
   , peersFromPeerIdList
   , peersFromPeerIdList'
   , peersFromPeerList
   , peersList
-  , peersOnlyAdversary
-  , peersOnlyHonest
   , toMap
   , toMap'
-  , unionWithKey
-  , updatePeer
   ) where
 
 import           Control.Monad ((>=>))

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -119,7 +119,7 @@ data Peer a =
     name  :: PeerId,
     value :: a
   }
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 instance Functor Peer where
   fmap f Peer {name, value} = Peer {name, value = f value}
@@ -152,7 +152,7 @@ data Peers a = Peers
   { honestPeers      :: Map Int a,
     adversarialPeers :: Map Int a
   }
-  deriving (Eq, Show, Traversable)
+  deriving (Eq, Show, Generic, Traversable)
 
 -- | Variant of 'honestPeers' that returns a map with 'PeerId's as keys.
 honestPeers' :: Peers a -> Map PeerId a

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -7,8 +7,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- | This module contains the definition of point schedule _peers_ as well as
--- all kind of utilities to manipulate them.
+-- | Simulating the protocol requires modeling the /peers/ in the network. This
+-- module defines peer related types and helpers to manipulate them. Peers are
+-- represented opaquely by a 'PeerId'.
 
 module Test.Consensus.PointSchedule.Peers (
     Peer (..)
@@ -238,11 +239,17 @@ peersList Peers {honestPeers, adversarialPeers} =
     )
     honestPeers
 
+-- | Generate the list of all adversarial peer IDs.
+--
+-- > enumerateAdversaries = fmap AdversarialPeer [1 ..]
 enumerateAdversaries :: [PeerId]
 enumerateAdversaries = AdversarialPeer <$> [1 ..]
 
 -- | Construct 'Peers' from values, adding adversary names based on the default schema.
-peers' :: [a] -> [a] -> Peers a
+peers'
+  :: [a]  -- ^ Honest values
+  -> [a]  -- ^ Adversarial values
+  -> Peers a
 peers' hs as =
   Peers
     { honestPeers = Map.fromList $ zip [1 ..] hs,
@@ -289,6 +296,9 @@ toMap' Peers {honestPeers, adversarialPeers} =
     (Map.mapKeysMonotonic HonestPeer honestPeers)
     (Map.mapKeysMonotonic AdversarialPeer adversarialPeers)
 
+-- | Convert 'Peers' to an explicit map from 'PeerId's to wrapped values.
+--
+-- INVARIANT: and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True
 toMap :: Peers a -> Map PeerId (Peer a)
 toMap = Map.mapWithKey Peer . toMap'
 
@@ -315,6 +325,7 @@ fromMap' peers =
 fromMap :: Map PeerId (Peer a) -> Peers a
 fromMap = fromMap' . Map.map value
 
+-- | Remove a peer.
 deletePeer :: PeerId -> Peers a -> Peers a
 deletePeer (HonestPeer n) Peers {honestPeers, adversarialPeers} =
   Peers {honestPeers = Map.delete n honestPeers, adversarialPeers}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -147,7 +147,7 @@ instance (QC.Arbitrary a) => QC.Arbitrary (Peer a) where
     value <- QC.arbitrary
     return Peer {..}
 
--- | General-purpose functor for a set of peers.
+-- | General-purpose functor for associating data to each of a set of peers.
 data Peers a = Peers
   { honestPeers      :: Map Int a,
     adversarialPeers :: Map Int a
@@ -245,6 +245,8 @@ getPeer :: PeerId -> Peers a -> Peer a
 getPeer (HonestPeer n) Peers {honestPeers} = Peer (HonestPeer n) (honestPeers Map.! n)
 getPeer (AdversarialPeer n) Peers {adversarialPeers} = Peer (AdversarialPeer n) (adversarialPeers Map.! n)
 
+-- | Apply a function to the value at a specific peer ID, returning the
+-- updated 'Peers' structure and the result of the function.
 updatePeer :: (a -> (a, b)) -> PeerId -> Peers a -> (Peers a, b)
 updatePeer f (HonestPeer n) Peers {honestPeers, adversarialPeers} =
   let (a, b) = f (honestPeers Map.! n)
@@ -324,6 +326,8 @@ toMap' Peers {honestPeers, adversarialPeers} =
 
 -- | Convert 'Peers' to an explicit map from 'PeerId's to wrapped values.
 --
+-- Returns a coherent map: the peer ID at each entry matches the entry's index. This
+-- is witnessed by the following invariant:
 -- INVARIANT: and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True
 toMap :: Peers a -> Map PeerId (Peer a)
 toMap = Map.mapWithKey Peer . toMap'

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -60,6 +60,7 @@ import           NoThunks.Class (NoThunks)
 import           Ouroboros.Consensus.Util.Condense (Condense (..),
                      CondenseList (..), PaddingDirection (..),
                      condenseListWithPadding)
+import qualified Test.QuickCheck as QC
 
 -- | Identifier used to index maps and specify which peer is active during a tick.
 data PeerId
@@ -106,7 +107,13 @@ instance Aeson.FromJSON PeerId where
       "adversarial" -> pure $ AdversarialPeer peerIndex
       (_ :: String) -> fail $ "Unknown peerType: " ++ peerType
 
--- | General-purpose functor associated with a peer.
+instance QC.Arbitrary PeerId where
+  arbitrary = QC.oneof
+    [ fmap (HonestPeer . QC.getNonNegative) QC.arbitrary
+    , fmap (AdversarialPeer . QC.getNonNegative) QC.arbitrary
+    ]
+
+-- | General-purpose functor for associating data to a peer.
 data Peer a =
   Peer {
     name  :: PeerId,
@@ -133,6 +140,12 @@ instance CondenseList a => CondenseList (Peer a) where
       (\name value -> name ++ ": " ++ value)
       (condenseList $ name <$> peers)
       (condenseList $ value <$> peers)
+
+instance (QC.Arbitrary a) => QC.Arbitrary (Peer a) where
+  arbitrary = do
+    name <- QC.arbitrary
+    value <- QC.arbitrary
+    return Peer {..}
 
 -- | General-purpose functor for a set of peers.
 data Peers a = Peers
@@ -169,6 +182,12 @@ instance Functor Peers where
 instance Foldable Peers where
   foldMap f Peers {honestPeers, adversarialPeers} =
     foldMap f honestPeers <> foldMap f adversarialPeers
+
+instance (QC.Arbitrary a) => QC.Arbitrary (Peers a) where
+  arbitrary = do
+    honestPeers <- QC.arbitrary
+    adversarialPeers <- QC.arbitrary
+    return Peers {..}
 
 peersToJSON :: Peers Aeson.Value -> Aeson.Value
 peersToJSON Peers {honestPeers, adversarialPeers} =

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Peers.hs
@@ -328,7 +328,7 @@ toMap' Peers {honestPeers, adversarialPeers} =
 --
 -- Returns a coherent map: the peer ID at each entry matches the entry's index. This
 -- is witnessed by the following invariant:
--- INVARIANT: and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True
+-- INVARIANT: and ( zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) ) == True
 toMap :: Peers a -> Map PeerId (Peer a)
 toMap = Map.mapWithKey Peer . toMap'
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -13,6 +14,7 @@ import           Data.Bifunctor (second)
 import           Data.Coerce (coerce)
 import           Data.List as List (foldl', group, isSuffixOf, partition, sort)
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map as Map
 import           Data.Maybe (isNothing)
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds,
                      picosecondsToDiffTime)
@@ -20,6 +22,7 @@ import           GHC.Stack (HasCallStack)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (blockHash)
 import           System.Random.Stateful (runSTGen_)
+import           Test.Consensus.PointSchedule.Peers
 import           Test.Consensus.PointSchedule.SinglePeer
 import           Test.Consensus.PointSchedule.SinglePeer.Indices
 import qualified Test.QuickCheck as QC
@@ -43,6 +46,7 @@ tests =
       , testProperty "tipPointSchedule" prop_tipPointSchedule
       , testProperty "headerPointSchedule" prop_headerPointSchedule
       , testProperty "peerScheduleFromTipPoints" prop_peerScheduleFromTipPoints
+      , testPeers
       ]
 
 prop_zipMany :: [[Int]] -> QC.Property
@@ -389,3 +393,13 @@ genSortedVectorWithoutDuplicates :: (QC.Arbitrary a, Num a, Ord a) => Int -> QC.
 genSortedVectorWithoutDuplicates n = do
     x0 <- QC.arbitrary
     scanl (+) x0 . map ((+1) . QC.getNonNegative) <$> QC.vector (n - 1)
+
+testPeers :: TestTree
+testPeers = testGroup "Peers"
+  -- 'toMap' returns a coherent map; an index and the peer ID at that index are equal.
+  [ testProperty "and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True" $
+    let mapSnd f (a, b) = (a, f b)
+    in \(peers :: Peers Int) -> QC.property $
+      QC.counterexample ("toMap peers = " ++ show (toMap peers)) $ QC.property $
+        and $ fmap (uncurry (==)) $ fmap (mapSnd name) $ Map.toList $ toMap peers
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -46,7 +46,7 @@ tests =
       , testProperty "tipPointSchedule" prop_tipPointSchedule
       , testProperty "headerPointSchedule" prop_headerPointSchedule
       , testProperty "peerScheduleFromTipPoints" prop_peerScheduleFromTipPoints
-      , testPeers
+      , testProperty "peersToMap" prop_peersToMap
       ]
 
 prop_zipMany :: [[Int]] -> QC.Property
@@ -394,11 +394,9 @@ genSortedVectorWithoutDuplicates n = do
     x0 <- QC.arbitrary
     scanl (+) x0 . map ((+1) . QC.getNonNegative) <$> QC.vector (n - 1)
 
-testPeers :: TestTree
-testPeers = testGroup "Peers"
-  -- 'toMap' returns a coherent map; an index and the peer ID at that index are equal.
-  [ testProperty "and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True" $
-    let mapSnd f (a, b) = (a, f b)
-    in \(peers :: Peers Int) -> QC.counterexample ("toMap peers = " ++ show (toMap peers)) $
-        and $ fmap (uncurry (==)) $ fmap (mapSnd name) $ Map.toList $ toMap peers
-  ]
+-- 'toMap' returns a coherent map; an index and the peer ID at that index are equal.
+prop_peersToMap :: Peers Int -> QC.Property
+prop_peersToMap =
+  let mapSnd f (a, b) = (a, f b)
+  in \(peers :: Peers Int) -> QC.counterexample ("toMap peers = " ++ show (toMap peers)) $
+      and $ fmap (uncurry (==)) $ fmap (mapSnd name) $ Map.toList $ toMap peers

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -399,7 +399,6 @@ testPeers = testGroup "Peers"
   -- 'toMap' returns a coherent map; an index and the peer ID at that index are equal.
   [ testProperty "and $ zipWith (==) $ fmap (mapSnd name) $ Map.toList (toMap peers) == True" $
     let mapSnd f (a, b) = (a, f b)
-    in \(peers :: Peers Int) -> QC.property $
-      QC.counterexample ("toMap peers = " ++ show (toMap peers)) $ QC.property $
+    in \(peers :: Peers Int) -> QC.counterexample ("toMap peers = " ++ show (toMap peers)) $
         and $ fmap (uncurry (==)) $ fmap (mapSnd name) $ Map.toList $ toMap peers
   ]


### PR DESCRIPTION
This refactoring patch is aimed at improving the organization and documentation of `unstable-consensus-conformance-testlib`, specifically in the module `Test.Consensus.PointSchedule.Peers`.

The commits are meant to be self contained and readable in order.

```
# relevant tests:
cabal test ouroboros-consensus-diffusion:consensus-test  --test-options='-p "/Peers/"'

# generate haddock:
cabal haddock ouroboros-consensus-diffusion:unstable-consensus-conformance-testlib --haddock-all --haddock-hyperlink-source --haddock-quickjump
```

This doesn't move or rename anything; just adding documentation and haddock structure.
