### PR TITLE
Add `KeyType` for rendering and serialization plus `All.TestKey` tests

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -243,8 +243,10 @@ library unstable-consensus-conformance-testlib
     Test.Consensus.Genesis.Tests.LongRangeAttack
     Test.Consensus.Genesis.Tests.Uniform
     Test.Consensus.Genesis.TestSuite
+    Test.Consensus.Genesis.TestSuite.All
     Test.Consensus.Genesis.TestSuite.SmallKey
     Test.Consensus.Genesis.TestSuite.SmallKey.Tests
+    Test.Consensus.Genesis.TestSuite.Tests
     Test.Consensus.HardFork.Combinator
     Test.Consensus.HardFork.Combinator.A
     Test.Consensus.HardFork.Combinator.B
@@ -298,6 +300,7 @@ library unstable-consensus-conformance-testlib
     containers,
     contra-tracer,
     directory,
+    extra ^>=1.8,
     fs-api ^>=0.3,
     fs-sim ^>=0.3,
     hashable,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -27,9 +28,20 @@ module Test.Consensus.Genesis.TestSuite (
   , newTestSuite
   , suiteKeys
   , toTestTree
+    -- * Key type rendering and serialization
+  , Key
+  , KeyType (..)
+  , keyName
+  , makeKey
+  , parseJSONKeyType
+  , superKey
+  , toJSONKeyType
   ) where
 
+import           Data.Aeson (FromJSON (..), ToJSON (..), Value)
+import qualified Data.Aeson.Types as Aeson
 import           Data.Foldable (toList)
+import           Data.List (intercalate)
 import           Data.Map.Monoidal (MonoidalMap)
 import qualified Data.Map.Monoidal as MMap
 import           Data.Map.Strict (Map)
@@ -57,6 +69,65 @@ import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Util.TersePrinting (Terse)
+
+{-------------------------------------------------------------------------------
+  Key type rendering and serialization
+-------------------------------------------------------------------------------}
+
+-- | A typeclass for types used as structured test keys.
+-- Instances convert a domain-specific key type @k@ into a 'Key'.
+class KeyType k where
+   toKey :: k -> Key
+
+-- | A structured test key representation to produce a stable, human-readable
+-- hierarchical name for a test, suitable for rendering and JSON serialization.
+--
+-- Keys can be nested by combining them with '<>'.
+newtype Key = Key {getKeySegments :: [String]}
+  deriving newtype (Eq, Semigroup, Monoid)
+
+instance ToJSON Key where
+  toJSON = toJSON . getKeySegments
+
+instance FromJSON Key where
+  parseJSON = fmap Key . parseJSON
+
+-- | Serialize a 'KeyType' to JSON by means of the 'Key' representation of its value.
+toJSONKeyType :: KeyType key => key -> Value
+toJSONKeyType = toJSON . toKey
+
+-- | Parse a JSON 'Value' as a 'SmallKey' by comparing it against the 'Key'
+-- representation of all its values.
+parseJSONKeyType :: (KeyType key, SmallKey key) => Value -> Aeson.Parser key
+parseJSONKeyType v = do
+  key <- parseJSON v
+  case filter (\k -> toKey k == key) allKeys of
+    [k] -> pure k
+    []  -> fail $ "parseJSONKeyType: unknown key " <> renderKeyName key
+    _   -> fail $ "parseJSONKeyType: ambiguous key " <> renderKeyName key
+
+-- | Create a 'Key' from a 'String'.
+makeKey :: String -> Key
+makeKey = Key . pure
+
+-- | Render a 'Key' as a human-readable string.
+renderKeyName :: Key -> String
+-- Produce a dot-separated string, e.g. @"group.subgroup.case"@.
+renderKeyName = intercalate "." . getKeySegments
+
+-- | Render the name of a 'KeyType' value as a human-readable string.
+keyName :: KeyType k => k -> String
+keyName = renderKeyName . toKey
+
+-- | Nest a key under a named group.
+--
+-- Useful for grouping related test keys under a common prefix.
+superKey :: KeyType k => String -> k -> Key
+superKey name x = makeKey name <> toKey x
+
+{-------------------------------------------------------------------------------
+  TestSuite API
+-------------------------------------------------------------------------------}
 
 data TestSuiteData blk = TestSuiteData
   { -- | A prefix representing a path through the test group tree.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/All.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/All.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Consensus.Genesis.TestSuite.All (
+    TestKey
+  , testSuite
+  ) where
+
+import           Data.Aeson (FromJSON (..), ToJSON (..))
+import           Ouroboros.Consensus.Block (GetHeader, HasHeader, Header,
+                     HeaderHash)
+import           Ouroboros.Consensus.Util.Condense (Condense)
+import           Test.Consensus.Genesis.Setup.GenChains (IssueTestBlock)
+import qualified Test.Consensus.Genesis.Tests as Genesis
+import           Test.Consensus.Genesis.TestSuite
+import qualified Test.Consensus.PeerSimulator.Tests as PeerSimulator
+
+-- | The type containing all the test keys.
+data TestKey = Genesis !Genesis.TestKey
+             | PeerSimulator !PeerSimulator.TestKey
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    Genesis k -> superKey "Genesis" k
+    PeerSimulator k -> superKey "PeerSimulator" k
+
+instance ToJSON TestKey where
+  toJSON = toJSONKeyType
+
+instance FromJSON TestKey where
+  parseJSON = parseJSONKeyType
+
+-- | The test suite containing all conformance tests.
+testSuite ::
+  ( Condense (HeaderHash blk)
+  , Condense (Header blk)
+  , Eq (Header blk)
+  , GetHeader blk
+  , HasHeader blk
+  , IssueTestBlock blk
+  , Ord blk
+  ) => TestSuite blk TestKey
+testSuite = mkTestSuite $ \case
+  Genesis k -> at Genesis.testSuite k
+  PeerSimulator k -> at PeerSimulator.testSuite k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/Tests.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Consensus.Genesis.TestSuite.Tests (tests) where
+
+import           Data.List.Extra (anySame)
+import           Test.Consensus.Genesis.TestSuite
+import qualified Test.Consensus.Genesis.TestSuite.All as All
+import           Test.Consensus.Genesis.TestSuite.SmallKey
+import qualified Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "TestSuite"
+  [ testCase "All test keys have distinct names" $
+      assertBool "Test key names must be unique" $
+        not . anySame $ fmap toKey $ allKeys @All.TestKey
+  ,  Test.Consensus.Genesis.TestSuite.SmallKey.Tests.tests
+  ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Consensus.Genesis.Tests (
-    GenesisTestKey
+    TestKey
   , testSuite
   , tests
   ) where
@@ -29,14 +29,23 @@ tests = testGroup "Genesis tests" $
   [GDD.tests] <> toTestTree @TestBlock testSuite
 
 -- | Each value of this type uniquely corresponds to a Genesis test.
-data GenesisTestKey = Uniform !Uniform.TestKey
+data TestKey = Uniform !Uniform.TestKey
              | CSJ !CSJ.TestKey
              | GDD !GDD.TestKey
              | LongRangeAttack !LongRangeAttack.TestKey
              | LoE !LoE.TestKey
              | LoP !LoP.TestKey
-  deriving stock (Eq, Ord, Generic)
-  deriving SmallKey via Generically GenesisTestKey
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    Uniform k -> superKey "Uniform" k
+    CSJ k -> superKey "CSJ" k
+    GDD k -> superKey "GDD" k
+    LongRangeAttack k -> superKey "LongRangeAttack" k
+    LoE k -> superKey "LoE" k
+    LoP k -> superKey "LoP" k
 
 testSuite ::
   ( HasHeader blk
@@ -45,11 +54,11 @@ testSuite ::
   , Condense (Header blk)
   , Ord blk
   , Eq (Header blk)
-  ) => TestSuite blk GenesisTestKey
+  ) => TestSuite blk TestKey
 testSuite = mkTestSuite $ \case
-  Uniform t -> at Uniform.testSuite t
-  CSJ t -> at CSJ.testSuite t
-  GDD t -> at GDD.testSuite t
-  LongRangeAttack t -> at LongRangeAttack.testSuite t
-  LoE t -> at LoE.testSuite t
-  LoP t -> at LoP.testSuite t
+  Uniform k -> at Uniform.testSuite k
+  CSJ k -> at CSJ.testSuite k
+  GDD k -> at GDD.testSuite k
+  LongRangeAttack k -> at LongRangeAttack.testSuite k
+  LoE k -> at LoE.testSuite k
+  LoP k -> at LoP.testSuite k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -58,8 +58,15 @@ data TestKey = WithNoAdversariesAndOneScheduleForAllPeers
              | WithNoAdversariesAndOneSchedulePerHonestPeer
              | WithAdversariesAndOneScheduleForAllPeers
              | WithAdversariesAndOneSchedulePerHonestPeer
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    WithNoAdversariesAndOneScheduleForAllPeers -> makeKey "WithNoAdversariesAndOneScheduleForAllPeers"
+    WithNoAdversariesAndOneSchedulePerHonestPeer -> makeKey "WithNoAdversariesAndOneSchedulePerHonestPeer"
+    WithAdversariesAndOneScheduleForAllPeers -> makeKey "WithAdversariesAndOneScheduleForAllPeers"
+    WithAdversariesAndOneSchedulePerHonestPeer -> makeKey "WithAdversariesAndOneSchedulePerHonestPeer"
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -87,8 +87,12 @@ adjustTestMaxSize = (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = TriggersChainSelection
-  deriving stock (Eq,Ord,Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    TriggersChainSelection -> makeKey "TriggersChainSelection"
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -46,8 +46,13 @@ adjustTestMaxSize = (`div` 5)
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = AdversaryDoesNotHitTimeouts
              | AdversaryHitsTimeouts
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    AdversaryDoesNotHitTimeouts -> makeKey "AdversaryDoesNotHitTimeouts"
+    AdversaryHitsTimeouts -> makeKey "AdversaryHitsTimeouts"
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -57,8 +57,18 @@ data TestKey = WaitJustEnoughUntilEmpty
              | ServeTooSlow
              | DelayAttackSucceeds
              | DelayAttackFails
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    WaitJustEnoughUntilEmpty -> makeKey "WaitJustEnoughUntilEmpty"
+    WaitTooMuchUntilEmpty -> makeKey "WaitTooMuchUntilEmpty"
+    WaitBehindForecastHorizon -> makeKey "WaitBehindForecastHorizon"
+    ServeJustFastEnough -> makeKey "ServeJustFastEnough"
+    ServeTooSlow -> makeKey "ServeTooSlow"
+    DelayAttackSucceeds -> makeKey "DelayAttackSucceeds"
+    DelayAttackFails -> makeKey "DelayAttackFails"
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -31,9 +31,13 @@ adjustDesiredPasses :: Int -> Int
 adjustDesiredPasses = (`div` 10)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
-data TestKey = LongRangeAttack
-  deriving stock (Eq, Ord, Generic)
+data TestKey = WithOneAdversary
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    WithOneAdversary -> makeKey "WithOneAdversary"
 
 testSuite ::
    (HasHeader blk
@@ -44,7 +48,7 @@ testSuite = group "long range attack" $ newTestSuite $ \case
   -- NOTE: We want to keep this test to show that Praos is vulnerable to this
   -- attack but Genesis is not. This requires to first fix it as mentioned
   -- below.
-  LongRangeAttack -> test_longRangeAttack
+  WithOneAdversary -> test_withOneAdversary
 
 -- | This test case features a long-range attack with one adversary. The honest
 -- peer serves the block tree trunk, while the adversary serves its own chain,
@@ -52,13 +56,13 @@ testSuite = group "long range attack" $ newTestSuite $ \case
 -- The adversary serves the chain more rapidly than the honest peer. We check at
 -- the end that the selection is honest. This property does not hold with Praos,
 -- but should hold with Genesis.
-test_longRangeAttack ::
+test_withOneAdversary ::
    forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   ) => ConformanceTest blk
-test_longRangeAttack =
+test_withOneAdversary =
   mkConformanceTest "one adversary" adjustDesiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -77,10 +77,19 @@ data TestKey = BlockFetchLeashingAttack
              | Downtime
              | LeashingAttackStalling
              | LeashingAttackTimeLimited
-             | LOEStalling
+             | LoeStalling
              | ServeAdversarialBranches
-  deriving stock (Eq, Show, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    BlockFetchLeashingAttack -> makeKey "BlockFetchLeashingAttack"
+    Downtime -> makeKey "Downtime"
+    LeashingAttackStalling -> makeKey "LeashingAttackStalling"
+    LeashingAttackTimeLimited -> makeKey "LeashingAttackTimeLimited"
+    LoeStalling -> makeKey "LoeStalling"
+    ServeAdversarialBranches -> makeKey "ServeAdversarialBranches"
 
 testSuite ::
   ( AF.HasHeader blk
@@ -93,7 +102,7 @@ testSuite = group "uniform" $ newTestSuite $ \case
     Downtime -> test_downtime
     LeashingAttackStalling -> test_leashingAttackStalling
     LeashingAttackTimeLimited -> test_leashingAttackTimeLimited
-    LOEStalling -> test_loeStalling
+    LoeStalling -> test_loeStalling
     ServeAdversarialBranches -> test_serveAdversarialBranches
 
 -- | The conjunction of

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Consensus.PeerSimulator.Tests (
-    SmokeTestKey
+    TestKey
   , testSuite
   , tests
   ) where
@@ -25,11 +25,17 @@ tests :: TestTree
 tests = testGroup "PeerSimulator" $ toTestTree @TestBlock testSuite
 
 -- | Each value of this type uniquely corresponds to a basic functionality test.
-data SmokeTestKey = LinkedThreads LinkedThreads.TestKey
-                  | Rollback Rollback.TestKey
-                  | Timeouts Timeouts.TestKey
-  deriving stock (Eq, Ord, Generic)
-  deriving SmallKey via Generically SmokeTestKey
+data TestKey = LinkedThreads LinkedThreads.TestKey
+             | Rollback Rollback.TestKey
+             | Timeouts Timeouts.TestKey
+  deriving stock (Show, Eq, Ord, Generic)
+  deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    LinkedThreads k -> superKey "LinkedThreads" k
+    Rollback k -> superKey "Rollback" k
+    Timeouts k -> superKey "Timeouts" k
 
 testSuite ::
   ( IssueTestBlock blk
@@ -38,8 +44,8 @@ testSuite ::
   , Condense (HeaderHash blk)
   , Condense (Header blk)
   , Eq blk
-  ) => TestSuite blk SmokeTestKey
+  ) => TestSuite blk TestKey
 testSuite = mkTestSuite $ \case
-  LinkedThreads t -> at LinkedThreads.testSuite t
-  Rollback t -> at Rollback.testSuite t
-  Timeouts t -> at Timeouts.testSuite t
+  LinkedThreads k -> at LinkedThreads.testSuite k
+  Rollback k -> at Rollback.testSuite k
+  Timeouts k -> at Timeouts.testSuite k

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -34,8 +34,12 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleHeaderPoint,
 import           Test.Util.Orphans.IOLike ()
 
 data TestKey = ChainSyncKillsBlockFetch
-  deriving (Eq, Ord, Generic)
+  deriving (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    ChainSyncKillsBlockFetch -> makeKey "ChainSyncKillsBlockFetch"
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -40,8 +40,13 @@ desiredPasses :: Int -> Int
 desiredPasses = (`div` 2)
 
 data TestKey = CanRollback | CannotRollback
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    CanRollback -> makeKey "CanRollback"
+    CannotRollback -> makeKey "CannotRollback"
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -40,8 +40,13 @@ desiredPasses = (`div` 10)
 
 data TestKey = DoesTimeout
              | DoesNotTimeout
-  deriving stock (Eq, Ord, Generic)
+  deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
+
+instance KeyType TestKey where
+  toKey = \case
+    DoesTimeout -> makeKey "DoesTimeout"
+    DoesNotTimeout -> makeKey "DoesNotTimeout"
 
 testSuite ::
   ( IssueTestBlock blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
@@ -26,6 +26,8 @@ import           Test.Consensus.Genesis.Tests.CSJ (genDuplicatedHonestSchedule)
 import           Test.Consensus.Genesis.Tests.Uniform
                      (genBlockFetchLeashingSchedule, genLeashingSchedule,
                      genTimeLimitedSchedule, genUniformSchedulePoints)
+import qualified Test.Consensus.Genesis.TestSuite.All as All
+import           Test.Consensus.Genesis.TestSuite.SmallKey
 import qualified Test.Consensus.PointSchedule as Schedule
 import           Test.Consensus.Serialize
 import qualified Test.QuickCheck as QC
@@ -92,6 +94,14 @@ tests = testGroup "JSON Serialization"
         \(blockTree, pointSchedule) ->
           prop_fromReifiedPointSchedule_rejects_unknown_point blockTree pointSchedule
     ]
+   , testGroup "TestKey" $
+    [ testProperty "toJSON . fromJSON . toJSON == toJSON" $
+      QC.forAll (genKey)
+        (prop_serialize_weak_inverse (Proxy @(All.TestKey)))
+    , testProperty "fromJSON . toJSON == id" $
+      QC.forAll (genKey)
+        (prop_deserialize_inverse (Proxy @(All.TestKey)))
+    ]
   ]
   where
     branchFactor = pure 5
@@ -146,6 +156,9 @@ genTestBlockTreeWithPointSchedule branchFactor = do
     , genBlockFetchLeashingSchedule
     ]
   pure (gtBlockTree genesisTest, schedule)
+
+genKey :: (SmallKey k) => QC.Gen k
+genKey = QC.elements allKeys
 
 shrinkBlockTree :: (HasHeader blk) => BlockTree blk -> [BlockTree blk]
 shrinkBlockTree (BlockTree trunk branches) = mconcat


### PR DESCRIPTION
This adds the `KeyType` type class machinery for the rendering of test key types in  https://github.com/tweag/cardano-node/pull/28

Also, a new `TestSuite.All` module is introduced to define the toplevel `TestSuite` and `TestKey`, containing all the conformance tests. `All.TestKey` is used to test that all our keys have different names when rendered; serialization rountrip tests are also defined (`Show` is derived for all test keys as required by the testing helpers).