### PR TITLE
Add aeson instances for GenesisTestKey

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -10,6 +10,7 @@ module Test.Consensus.Genesis.Tests (
   , tests
   ) where
 
+import qualified Data.Aeson as Aeson
 import           Ouroboros.Consensus.Block.Abstract (GetHeader, HasHeader,
                      Header)
 import           Ouroboros.Consensus.Util.Condense (Condense)
@@ -37,6 +38,19 @@ data GenesisTestKey = Uniform !Uniform.TestKey
              | LoP !LoP.TestKey
   deriving stock (Eq, Ord, Generic)
   deriving SmallKey via Generically GenesisTestKey
+
+instance Aeson.ToJSON GenesisTestKey where
+  toJSON = error "ToJSON GenesisTestKey: not yet implemented"
+    -- TODO(nbloomf): fix this once test keys are implemented
+    -- Aeson.toJSON . keyName
+
+instance Aeson.FromJSON GenesisTestKey where
+  parseJSON = Aeson.withText "GenesisTestKey" $ \_ ->
+    error "FromJSON GenesisTestKey: not yet implemented"
+    -- TODO(nbloomf): fix this once test keys are implemented
+    -- case parseKeyName $ T.unpack t of
+    --  Just k -> pure k
+    --  Nothing -> fail $ "Unrecognized key name: " <> show t
 
 testSuite ::
   ( HasHeader blk

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule.hs
@@ -661,8 +661,6 @@ ensureScheduleDuration gt PointSchedule{psSchedule, psStartOrder, psMinEndTime} 
     peerCount = length (peersList psSchedule)
     adversaryCount = Map.size (adversarialPeers psSchedule)
 
-
-
 -- | This class exists to house some of the functions required of a block
 -- type in order to be used by point schedule tests in 'nodeLifecycle'. It
 -- was introduced to help generalize the tests from TestBlocks to live block


### PR DESCRIPTION
Depends on https://github.com/tweag/ouroboros-consensus-testing/pull/54

(Will update this once test key parsing API is stabilized)

Test keys need To/FromJSON instances for serialization; this adds them for GenesisTestKey.