### PR TITLE
Add flag to disable VRF checks

### DIFF
--- a/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
+++ b/ouroboros-consensus-protocol/ouroboros-consensus-protocol.cabal
@@ -26,6 +26,11 @@ flag asserts
   manual: False
   default: False
 
+flag disable-vrf-checks
+  description: Disable VRF signature checks in doValidateVRFSignature
+  manual: True
+  default: False
+
 common common-lib
   default-language: Haskell2010
   ghc-options:
@@ -52,6 +57,8 @@ common common-test
 library
   import: common-lib
   hs-source-dirs: src/ouroboros-consensus-protocol
+  if flag(disable-vrf-checks)
+    cpp-options: -DDISABLE_VRF_CHECKS
   exposed-modules:
     Ouroboros.Consensus.Protocol.Ledger.HotKey
     Ouroboros.Consensus.Protocol.Ledger.Util

--- a/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -13,6 +14,11 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
+
+#ifdef DISABLE_VRF_CHECKS
+{-# OPTIONS -Wno-unused-imports #-}
+{-# OPTIONS -Wno-redundant-constraints #-}
+#endif
 
 module Ouroboros.Consensus.Protocol.Praos (
     ConsensusConfig (..)
@@ -539,6 +545,9 @@ doValidateVRFSignature ::
   ActiveSlotCoeff ->
   Views.HeaderView c ->
   Except (PraosValidationErr c) ()
+#ifdef DISABLE_VRF_CHECKS
+doValidateVRFSignature _eta0 _pd _f _b = pure ()
+#else
 doValidateVRFSignature eta0 pd f b = do
   case Map.lookup hk pd of
     Nothing -> throwError $ VRFKeyUnknown hk
@@ -561,6 +570,7 @@ doValidateVRFSignature eta0 pd f b = do
     vrfCert = Views.hvVrfRes b
     vrfLeaderVal = vrfLeaderValue (Proxy @c) vrfCert
     slot = Views.hvSlotNo b
+#endif
 
 validateKESSignature ::
   PraosCrypto c =>


### PR DESCRIPTION
# Description

This PR stubs out VRF checks, since they cannot be forged by our test runner.

VRF checks can be disabled by invoking

```
cabal build -f ouroboros-consensus-protocol:+disable-vrf-checks
```