### PR TITLE
Test suite backports

### DIFF
--- a/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
+++ b/ouroboros-consensus-diffusion/ouroboros-consensus-diffusion.cabal
@@ -307,7 +307,7 @@ library unstable-consensus-conformance-testlib
     io-classes,
     io-sim,
     mempack,
-    monoidal-containers,
+    monoidal-containers ^>=0.6,
     mtl,
     nothunks,
     ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.Genesis.Setup (
@@ -88,9 +87,9 @@ data ConformanceTest blk = ConformanceTest
     -- ^ A shrinker allowed to inspect the output value of a test.
   , ctProperty        :: GenesisTestFull blk -> StateView blk -> Property
     -- ^ The property to test.
-  , ctDesiredPasses   :: Int -> Int
+  , ctAdjustPasses   :: Int -> Int
     -- ^ Adjust the default number of test runs to check the property.
-  , ctMaxSize :: Int -> Int
+  , ctAdjustMaxSize :: Int -> Int
     -- ^ Adjust the default test case maximum size.
   , ctDescription :: String
     -- ^ A description for the test.
@@ -102,21 +101,36 @@ data ConformanceTest blk = ConformanceTest
   }
 
 mkConformanceTest ::
-  (Testable prop)
-  => String  -- ^ Test description.
-  -> TestVersion
-  -- ^ Test version. Please increment this value every time the generator,
+  Testable prop =>
+  -- | Test description.
+  String ->
+  -- | Test version. Please increment this value every time the generator,
   -- shrinker or configuration is changed.
-  -> (Int -> Int) -- ^ Transformation of the default desired test passes/successes.
-  -> (Int -> Int) -- ^ Transformation of the default max test size.
-  -> Gen (GenesisTestFull blk) -- ^ Test generator.
-  -> SchedulerConfig -- ^ Peer simulator scheduler configuration.
-  -> (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) -- ^ Result inspecting shrinker.
-  -> (GenesisTestFull blk -> StateView blk -> prop) -- ^ Property on test result.
-  -> ConformanceTest blk
-mkConformanceTest ctDescription ctVersion ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
+  TestVersion->
+  -- | Transformation of the default desired test passes/successes.
+  (Int -> Int) ->
+  -- | Transformation of the default max test size.
+  (Int -> Int) ->
+  -- | Test generator.
+  Gen (GenesisTestFull blk) ->
+  -- | Peer simulator scheduler configuration.
+  SchedulerConfig ->
+  -- | Result inspecting shrinker.
+  (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) ->
+  -- | Property on test result.
+  (GenesisTestFull blk -> StateView blk -> prop) ->
+  ConformanceTest blk
+mkConformanceTest ctDescription ctVersion ctAdjustPasses ctAdjustMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
   let ctProperty = fmap property . mkProperty
-   in ConformanceTest {..}
+   in ConformanceTest
+        { ctDescription
+        , ctAdjustPasses
+        , ctAdjustMaxSize
+        , ctGenerator
+        , ctSchedulerConfig
+        , ctShrinker
+        , ctProperty
+        }
 
 -- | Like 'runSimStrictShutdown' but fail when the main thread terminates if
 -- there are other threads still running or blocked. If one is trying to follow
@@ -167,6 +181,11 @@ runGenesisTest protocolInfoArgs schedulerConfig genesisTest =
 -- | Variant of 'runGenesisTest' that also takes a property on the final
 -- 'StateView' and returns a QuickCheck property. The trace is printed in case
 -- of counter-example.
+-- TODO: This function was unused before the introduction of 'ConformanceTest';
+-- we should decide if its worth keeping around. When testing other
+-- implementations of the protocol (via the Conformance Testing of Consensus
+-- harness) we won't have a 'StateView' to check properties on. However, it seems
+-- plausible this functionality could be leveraged for internal testing purposes.
 _runGenesisTest' ::
   Testable prop =>
   SchedulerConfig ->
@@ -182,7 +201,8 @@ _runGenesisTest' schedulerConfig genesisTest makeProperty = idempotentIOProperty
 -- | All-in-one helper that generates a 'GenesisTest' and a 'Peers
 -- PeerSchedule' from a 'ConformanceTest', runs them with 'runGenesisTest',
 -- and checks whether the given property holds on the resulting 'StateView'.
-runConformanceTest :: forall blk.
+runConformanceTest ::
+  forall blk.
   ( Condense (StateView blk)
   , CondenseList (NodeState blk)
   , ShowProxy blk
@@ -202,49 +222,66 @@ runConformanceTest :: forall blk.
   , Condense (NodeState blk)
   ) =>
   ConformanceTest blk -> TestTree
-runConformanceTest ConformanceTest {..} =
-  adjustQuickCheckTests ctDesiredPasses $
-  adjustQuickCheckMaxSize ctMaxSize $
-  QC.testProperty ctDescription $ idempotentIOProperty $ do
-    protocolInfoArgs <- getProtocolInfoArgs
-    pure $ forAllGenRunShrinkCheck ctGenerator (runGenesisTest protocolInfoArgs ctSchedulerConfig) shrinker' $ \genesisTest result ->
-      let cls = classifiers genesisTest
-          resCls = resultClassifiers genesisTest result
-          schCls = scheduleClassifiers genesisTest
-          stateView = rgtrStateView result
-      in classify (allAdversariesSelectable cls) "All adversaries have more than k blocks after intersection" $
-          classify (allAdversariesForecastable cls) "All adversaries have at least 1 forecastable block after intersection" $
-          classify (allAdversariesKPlus1InForecast cls) "All adversaries have k+1 blocks in forecast window after intersection" $
-          classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection" $
-          classify (adversaryRollback schCls) "An adversary did a rollback" $
-          classify (honestRollback schCls) "The honest peer did a rollback" $
-          classify (allAdversariesEmpty schCls) "All adversaries have empty schedules" $
-          classify (allAdversariesTrivial schCls) "All adversaries have trivial schedules" $
-          tabulate "Adversaries killed by LoP" [printf "%.1f%%" $ adversariesKilledByLoP resCls] $
-          tabulate "Adversaries killed by GDD" [printf "%.1f%%" $ adversariesKilledByGDD resCls] $
-          tabulate "Adversaries killed by Timeout" [printf "%.1f%%" $ adversariesKilledByTimeout resCls] $
-          tabulate "Surviving adversaries" [printf "%.1f%%" $ adversariesSurvived resCls] $
-          counterexample (rgtrTrace result) $
-          ctProperty genesisTest stateView .&&. hasOnlyExpectedExceptions stateView
-  where
-    shrinker' gt = ctShrinker gt . rgtrStateView
-    hasOnlyExpectedExceptions StateView{svPeerSimulatorResults} =
-      conjoin $ isExpectedException <$> mapMaybe
-        (pscrToException . pseResult)
-        svPeerSimulatorResults
-    isExpectedException exn
-      | Just EmptyBucket           <- e = true
-      | Just DensityTooLow         <- e = true
-      | Just (ExceededTimeLimit _) <- e = true
-      | Just AsyncCancelled        <- e = true
-      | Just CandidateTooSparse{}  <- e = true
-      | otherwise = counterexample
-        ("Encountered unexpected exception: " ++ show exn)
-        False
-      where
-        e :: (Exception e) => Maybe e
-        e = fromException exn
-        true = property True
+runConformanceTest conformanceTest =
+  adjustQuickCheckTests ctAdjustPasses . adjustQuickCheckMaxSize ctAdjustMaxSize $
+    QC.testProperty ctDescription . idempotentIOProperty $ do
+      protocolInfoArgs <- getProtocolInfoArgs
+      pure $
+        forAllGenRunShrinkCheck ctGenerator (runGenesisTest protocolInfoArgs ctSchedulerConfig) shrinker' $
+          \genesisTest result ->
+            let cls = classifiers genesisTest
+                resCls = resultClassifiers genesisTest result
+                schCls = scheduleClassifiers genesisTest
+                stateView = rgtrStateView result
+             in classify (allAdversariesSelectable cls) "All adversaries have more than k blocks after intersection"
+                  $ classify
+                    (allAdversariesForecastable cls)
+                    "All adversaries have at least 1 forecastable block after intersection"
+                  $ classify
+                    (allAdversariesKPlus1InForecast cls)
+                    "All adversaries have k+1 blocks in forecast window after intersection"
+                  $ classify (genesisWindowAfterIntersection cls) "Full genesis window after intersection"
+                  $ classify (adversaryRollback schCls) "An adversary did a rollback"
+                  $ classify (honestRollback schCls) "The honest peer did a rollback"
+                  $ classify (allAdversariesEmpty schCls) "All adversaries have empty schedules"
+                  $ classify (allAdversariesTrivial schCls) "All adversaries have trivial schedules"
+                  $ tabulate "Adversaries killed by LoP" [printf "%.1f%%" $ adversariesKilledByLoP resCls]
+                  $ tabulate "Adversaries killed by GDD" [printf "%.1f%%" $ adversariesKilledByGDD resCls]
+                  $ tabulate "Adversaries killed by Timeout" [printf "%.1f%%" $ adversariesKilledByTimeout resCls]
+                  $ tabulate "Surviving adversaries" [printf "%.1f%%" $ adversariesSurvived resCls]
+                  $ counterexample (rgtrTrace result)
+                  $ ctProperty genesisTest stateView .&&. hasOnlyExpectedExceptions stateView
+ where
+  ConformanceTest
+    { ctAdjustPasses
+    , ctAdjustMaxSize
+    , ctDescription
+    , ctGenerator
+    , ctSchedulerConfig
+    , ctShrinker
+    , ctProperty
+    } = conformanceTest
+  shrinker' gt = ctShrinker gt . rgtrStateView
+  hasOnlyExpectedExceptions StateView{svPeerSimulatorResults} =
+    conjoin $
+      isExpectedException
+        <$> mapMaybe
+          (pscrToException . pseResult)
+          svPeerSimulatorResults
+  isExpectedException exn
+    | Just EmptyBucket <- e = true
+    | Just DensityTooLow <- e = true
+    | Just (ExceededTimeLimit _) <- e = true
+    | Just AsyncCancelled <- e = true
+    | Just CandidateTooSparse{} <- e = true
+    | otherwise =
+        counterexample
+          ("Encountered unexpected exception: " ++ show exn)
+          False
+   where
+    e :: Exception e => Maybe e
+    e = fromException exn
+    true = property True
 
 -- | The 'StateView.svSelectedChain' produces an 'AnchoredFragment (Header blk)';
 -- this function casts this type's hash to its instance, so that it can be used

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -8,7 +8,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Consensus.Genesis.Setup (
-    ConformanceTest (..)
+    AdjustMaxSize (..)
+  , AdjustTestCount (..)
+  , ConformanceTest (..)
   , module Test.Consensus.Genesis.Setup.GenChains
   , TestVersion (..)
   , castHeaderHash
@@ -87,9 +89,9 @@ data ConformanceTest blk = ConformanceTest
     -- ^ A shrinker allowed to inspect the output value of a test.
   , ctProperty        :: GenesisTestFull blk -> StateView blk -> Property
     -- ^ The property to test.
-  , ctAdjustPasses   :: Int -> Int
+  , ctAdjustTestCount :: AdjustTestCount
     -- ^ Adjust the default number of test runs to check the property.
-  , ctAdjustMaxSize :: Int -> Int
+  , ctAdjustMaxSize :: AdjustMaxSize
     -- ^ Adjust the default test case maximum size.
   , ctDescription :: String
     -- ^ A description for the test.
@@ -100,17 +102,23 @@ data ConformanceTest blk = ConformanceTest
     -- time the generator, shrinker, or configuration is changed.
   }
 
+-- | A 'ConformanceTest' field type for the adjustment of required number of test runs.
+newtype AdjustTestCount = AdjustTestCount (Int -> Int)
+
+-- | A 'ConformanceTest' field type for maximum test case size adjustment.
+newtype AdjustMaxSize = AdjustMaxSize (Int -> Int)
+
 mkConformanceTest ::
   Testable prop =>
   -- | Test description.
   String ->
   -- | Test version. Please increment this value every time the generator,
   -- shrinker or configuration is changed.
-  TestVersion->
-  -- | Transformation of the default desired test passes/successes.
-  (Int -> Int) ->
-  -- | Transformation of the default max test size.
-  (Int -> Int) ->
+  TestVersion ->
+  -- | Adjustment of the default number of required test runs.
+  AdjustTestCount ->
+  -- | Adjustment of the default maximum test size.
+  AdjustMaxSize ->
   -- | Test generator.
   Gen (GenesisTestFull blk) ->
   -- | Peer simulator scheduler configuration.
@@ -120,11 +128,12 @@ mkConformanceTest ::
   -- | Property on test result.
   (GenesisTestFull blk -> StateView blk -> prop) ->
   ConformanceTest blk
-mkConformanceTest ctDescription ctVersion ctAdjustPasses ctAdjustMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
+mkConformanceTest ctDescription ctVersion ctAdjustTestCount ctAdjustMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
   let ctProperty = fmap property . mkProperty
    in ConformanceTest
         { ctDescription
-        , ctAdjustPasses
+        , ctVersion
+        , ctAdjustTestCount
         , ctAdjustMaxSize
         , ctGenerator
         , ctSchedulerConfig
@@ -161,8 +170,9 @@ runGenesisTest ::
   , Eq blk
   , Terse blk
   , Condense (NodeState blk)
-  )
-  => ProtocolInfoArgs blk -> SchedulerConfig ->
+  ) =>
+  ProtocolInfoArgs blk ->
+  SchedulerConfig ->
   GenesisTestFull blk ->
   RunGenesisTestResult blk
 runGenesisTest protocolInfoArgs schedulerConfig genesisTest =
@@ -223,7 +233,7 @@ runConformanceTest ::
   ) =>
   ConformanceTest blk -> TestTree
 runConformanceTest conformanceTest =
-  adjustQuickCheckTests ctAdjustPasses . adjustQuickCheckMaxSize ctAdjustMaxSize $
+  adjustQuickCheckTests atc . adjustQuickCheckMaxSize ams $
     QC.testProperty ctDescription . idempotentIOProperty $ do
       protocolInfoArgs <- getProtocolInfoArgs
       pure $
@@ -253,8 +263,8 @@ runConformanceTest conformanceTest =
                   $ ctProperty genesisTest stateView .&&. hasOnlyExpectedExceptions stateView
  where
   ConformanceTest
-    { ctAdjustPasses
-    , ctAdjustMaxSize
+    { ctAdjustTestCount = AdjustTestCount atc
+    , ctAdjustMaxSize = AdjustMaxSize ams
     , ctDescription
     , ctGenerator
     , ctSchedulerConfig

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -190,7 +190,7 @@ newTestSuite toConformanceTest =
 at :: Ord key => TestSuite blk key -> key ->  TestSuiteData blk
 at (TestSuite m) k = case Map.lookup k m of
   Just t  -> t
-  Nothing -> error "TestSuite.get: Impossible! A TestSuite is a total map."
+  Nothing -> error "TestSuite.at: Impossible! A TestSuite is a total map."
 
 getTest :: TestSuiteData blk ->  ConformanceTest blk
 getTest = tsTest

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -24,6 +24,7 @@ module Test.Consensus.Genesis.TestSuite (
   , at
   , getTest
   , group
+  , grouping
   , mkTestSuite
   , newTestSuite
   , suiteKeys
@@ -63,7 +64,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense, CondenseList)
 import           Ouroboros.Network.Util.ShowProxy (ShowProxy)
 import           Test.Consensus.Genesis.Setup (ConformanceTest (..),
                      runConformanceTest)
-import           Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (..))
+import           Test.Consensus.Genesis.TestSuite.SmallKey
 import           Test.Consensus.PeerSimulator.StateView (StateView)
 import           Test.Consensus.PointSchedule (HasPointScheduleTestParams)
 import           Test.Consensus.PointSchedule.NodeState (NodeState)
@@ -101,7 +102,7 @@ toJSONKeyType = toJSON . toKey
 parseJSONKeyType :: (KeyType key, SmallKey key) => Value -> Aeson.Parser key
 parseJSONKeyType v = do
   key <- parseJSON v
-  case filter (\k -> toKey k == key) allKeys of
+  case filter (\k -> toKey k == key) getAllKeys of
     [k] -> pure k
     []  -> fail $ "parseJSONKeyType: unknown key " <> renderKeyName key
     _   -> fail $ "parseJSONKeyType: ambiguous key " <> renderKeyName key
@@ -151,7 +152,7 @@ mkTestSuite :: (Ord key, SmallKey key)
                  => (key -> TestSuiteData blk)
                  -> TestSuite blk key
 mkTestSuite toData =
-  TestSuite . Map.fromList . fmap ((,) <$> id <*> toData) $ allKeys
+  TestSuite . Map.fromList . fmap ((,) <$> id <*> toData) $ getAllKeys
 
 -- | Build a 'TestSuite' from a function mapping a @key@ type to 'ConformanceTest'
 -- making all tests top-level.
@@ -171,17 +172,20 @@ newTestSuite toConformanceTest =
 --
 -- NOTE [DeriveSmallKey]
 -- The 'SmallKey' constraint on 'TestSuite' @key@s is meant to be derived
--- 'via Generically' only; because of this, some its class methods are not
+-- @via Generically@ only; because of this, some its class methods are not
 -- exported to prevent users of this class from instantiating it for large
 -- finite data types (such as 'Int' or 'Word32'), which are likely to flood the
 -- memory when constructing a 'TestSuite' because 'allKeys' are used
 -- operationally to drive its exhaustive construction. As precaution, product
--- and syntactically-recursive types are forbidden from instanciating it and some
--- large types have been explicitly black-listed.
+-- and syntactically-recursive types are forbidden from instanciating it and
+-- some large types have been explicitly black-listed.
 --
 -- The rationale behind the enforced restrictions is that @keys@ are expected
--- to be constructed primarily from user defined sum types of nullary
--- constructors corresponding to single test properties.
+-- to be constructed /primarily/ from user defined enumeration types (i.e.
+-- coproducts of nullary constructors) corresponding to single tests
+-- module wise, but this is not a hard requirement. For instance, keys can be
+-- aggregated into higher order types to define hierarchical 'TestSuite's
+-- by means of 'mkTestSuite' and 'at'.
 
 at :: Ord key => TestSuite blk key -> key ->  TestSuiteData blk
 at (TestSuite m) k = case Map.lookup k m of
@@ -191,17 +195,27 @@ at (TestSuite m) k = case Map.lookup k m of
 getTest :: TestSuiteData blk ->  ConformanceTest blk
 getTest = tsTest
 
--- | Appends the given string to the prefix of all tests.
+-- | Appends the given string to the prefix of all tests in the 'TestSuite',
+-- effectively grouping them on a `TestTree` of the given name when compiled.
 group :: String -> TestSuite blk key -> TestSuite blk key
-group pfs (TestSuite m) = TestSuite $
-  Map.map (\testData ->
-             testData {tsPrefix = pfs : tsPrefix testData}) m
+group name = grouping (const name)
+
+-- | A more general version of 'group' that allows to group tests by a key
+-- specific prefix.
+grouping :: (key -> String) -> TestSuite blk key -> TestSuite blk key
+grouping f (TestSuite m) =
+  TestSuite $
+    Map.mapWithKey
+      (\k testData -> testData{tsPrefix = f k : tsPrefix testData})
+      m
 
 -- | Produce the list of test keys contained in a 'TestSuite'.
 suiteKeys :: TestSuite blk key -> [key]
 suiteKeys (TestSuite m) = Map.keys m
 
--- * Compile 'TestSuite' into a 'TestTree'
+{-------------------------------------------------------------------------------
+   Compile a TestSuite into a TestTree
+-------------------------------------------------------------------------------}
 
 -- | Intermediary representation for a 'TestSuite' to be compiled into a 'TestTree'.
 data TestTrie = TestTrie

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey.hs
@@ -11,69 +11,88 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Internal module defining the 'SmallKey' utiliy class for 'TestSuite'
--- construction. Exposed through `Test.Consensus.Genesis.TestSuite` re-exports.
-module Test.Consensus.Genesis.TestSuite.SmallKey (SmallKey (allKeys)) where
+-- construction. Exposed through 'Test.Consensus.Genesis.TestSuite' re-exports.
+module Test.Consensus.Genesis.TestSuite.SmallKey (
+    SmallKey -- class method is not exported to prevent bespoke instances
+  , getAllKeys
+  ) where
 
+import           Data.Int
 import           Data.Kind
 import           Data.Proxy
+import           Data.Text (Text)
 import           Data.Word
 import           GHC.Generics
 import           GHC.TypeError
 import           Type.Reflection
 
--- | Creating an instance of this class is a declaration that the type has a
--- /small/ finite number of values and that 'allKeys' constains them all.
--- \"Small\" here is a safety requirement, meaning that it is feasible to
--- drive an exhaustive construction from its values.
+-- | This class is meant to be derived 'Generically' for the construction of
+-- 'TestSuite's only. Which is done in basically two settings:
+--
+-- 1. For enumeration types matching the 'ConformanceTest's in a module one-to-one.
+-- 2. For sums of other 'SmallKey' types for the composition of 'TestSuite's.
+--
+-- In essence, deriving an instance of this class is a declaration that the
+-- type has a /small/ finite number of values and that 'allKeys' ('getAllKeys')
+-- constains them all. \"Small\" here is a performance requirement, meaning that
+-- it is feasible to drive an exhaustive construction from its values.
 --
 -- /Laws:/
 --
--- @
--- 'elem' x 'allKeys'                         -- Any inhabitant has a finite index
--- 'length' ('filter' (== x) 'allKeys') == 1  -- Should terminate
--- @
+-- Any inhabitant of a 'SmallKey' type must have a finite index in 'allKeys',
+-- which must contain no duplicates. That is, whenever we have an 'Eq'
+-- instance for the type, the following should hold:
 --
+-- @
+-- 'elem' x 'allKeys' ==> 'length' ('filter' (== x) 'allKeys') == 1
+-- @
 class SmallKey a where
-    allKeys :: [a]
+  allKeys :: [a]
+
+getAllKeys :: SmallKey k => [k]
+getAllKeys = allKeys
 
 instance
   ( Generic a
   , AssertNotRecursive a (Rep a)
   , GSmallKey (Rep a)
-  ) => SmallKey (Generically a) where
+  ) =>
+  SmallKey (Generically a)
+  where
   allKeys = fmap (Generically . to) $ gAllKeys @(Rep a)
 
---------------------------------------------------------------------------------
--- TODO [Blacklist]
---
--- If @base ^>=4.19.0.0@, then `GHC.TypeError.Unsatisfiable` +
--- `GHC.TypeError.unsatisfiable` can be used to black-list types instead of
--- 'TypeError' + 'error', allowing a finer triggering of the error.
---
--- See https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0433-unsatisfiable.rst
---------------------------------------------------------------------------------
+{-------------------------------------------------------------------------------
+  TODO [Blacklist]
+
+  If @base ^>=4.19.0.0@, then `GHC.TypeError.Unsatisfiable` +
+  `GHC.TypeError.unsatisfiable` can be used to black-list types instead of
+  'TypeError' + 'error', allowing finer triggering of the error that
+  could be used to improve the 'SmallKey.Tests' (at least in principle).
+
+  See https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0433-unsatisfiable.rst
+-------------------------------------------------------------------------------}
 
 type family AssertNotRecursive (a :: Type) (f :: Type -> Type) :: Constraint where
   -- Throw type error if a direct recursive occurrence of the data type is found
   -- in its generic representation.
   AssertNotRecursive a (Rec0 a) =
-    TypeError ( 'Text "Recursive data types are not allowed "
-                ':<>: 'Text "to have a SmallKey instance: " ':<>: 'ShowType a)
-
+    TypeError
+      ( 'Text "Recursive data types are not allowed "
+          ':<>: 'Text "to have a SmallKey instance: "
+          ':<>: 'ShowType a
+      )
   AssertNotRecursive _ (Rec0 _) = ()
-
   AssertNotRecursive a (l :+: r) =
     (AssertNotRecursive a l, AssertNotRecursive a r)
-
   AssertNotRecursive a (l :*: r) =
     (AssertNotRecursive a l, AssertNotRecursive a r)
-
   AssertNotRecursive a (M1 _ _ f) =
     AssertNotRecursive a f
-
   AssertNotRecursive _ _ = ()
 
--- * Generic instance of 'SmallKey'
+{-------------------------------------------------------------------------------
+  SmallKey generic instance
+-------------------------------------------------------------------------------}
 
 class GSmallKey f where
   gAllKeys :: [f a]
@@ -87,9 +106,13 @@ instance GSmallKey U1 where
 instance (GSmallKey f, GSmallKey g) => GSmallKey (f :+: g) where
   gAllKeys = fmap L1 gAllKeys <> fmap R1 gAllKeys
 
-instance TypeError ('Text "Product types are not allowed "
-                    ':<>: 'Text "to have a SmallKey instance" )
-  => GSmallKey (f :*: g) where
+instance
+  TypeError
+    ( 'Text "Product types are not allowed "
+        ':<>: 'Text "to have a SmallKey instance"
+    ) =>
+  GSmallKey (f :*: g)
+  where
   gAllKeys = error "unreachable: product type"
 
 instance GSmallKey f => GSmallKey (M1 i c f) where
@@ -98,7 +121,13 @@ instance GSmallKey f => GSmallKey (M1 i c f) where
 instance SmallKey a => GSmallKey (K1 r a) where
   gAllKeys = fmap K1 allKeys
 
--- * Bundled instances
+{-------------------------------------------------------------------------------
+  Bundled instances
+
+  These are the instances of 'SmallKey' for common types deemed small enough
+  to be used exhaustively for 'TestSuite' construction, and that we expect
+  could be used in 'TestKey' types.
+-------------------------------------------------------------------------------}
 
 instance SmallKey () where
   allKeys = [()]
@@ -106,25 +135,49 @@ instance SmallKey () where
 instance SmallKey Bool where
   allKeys = [False, True]
 
--- * Black-listed instances of large types.
+{-------------------------------------------------------------------------------
+  Black-listed instances
+-------------------------------------------------------------------------------}
 
+-- | A constraint for black-listed 'SmallKey' instances of large types.
+--
+-- We explicitly forbid instances for types deemed too large for exhaustive
+-- construction. The 'TypeError' in this type family will be triggered if an
+-- attempt is made to use 'allKeys', for any type having it in its instance
+-- context.
 type family NoSmallKey ty :: Constraint where
   NoSmallKey ty =
-    TypeError ('ShowType ty ':<>: 'Text " doesn't have a SmallKey instance"
-               ':$$: 'Text "because it is too large for exhaustive construction")
-
+    TypeError
+      ( 'ShowType ty ':<>: 'Text " doesn't have a SmallKey instance"
+          ':$$: 'Text "because it is too large for exhaustive construction"
+      )
 
 unreachableSK :: forall a. Typeable a => Proxy a -> String
 unreachableSK _ = "unreachable: NoSmallKey " <> show (typeRep @a)
 
-instance NoSmallKey Integer  => SmallKey Integer where
+instance NoSmallKey Integer => SmallKey Integer where
   allKeys = error $ unreachableSK (Proxy :: Proxy Integer)
 
 instance NoSmallKey Int => SmallKey Int where
   allKeys = error $ unreachableSK (Proxy :: Proxy Int)
 
+instance NoSmallKey Int8 => SmallKey Int8 where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Int8)
+
+instance NoSmallKey Int16 => SmallKey Int16 where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Int16)
+
+instance NoSmallKey Int32 => SmallKey Int32 where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Int32)
+
+instance NoSmallKey Int64 => SmallKey Int64 where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Int64)
+
 instance NoSmallKey Word => SmallKey Word where
   allKeys = error $ unreachableSK (Proxy :: Proxy Word)
+
+instance NoSmallKey Word8 => SmallKey Word8 where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Word8)
 
 instance NoSmallKey Word16 => SmallKey Word16 where
   allKeys = error $ unreachableSK (Proxy :: Proxy Word16)
@@ -137,3 +190,6 @@ instance NoSmallKey Word64 => SmallKey Word64 where
 
 instance NoSmallKey Char => SmallKey Char where
   allKeys = error $ unreachableSK (Proxy :: Proxy Char)
+
+instance NoSmallKey Text => SmallKey Text where
+  allKeys = error $ unreachableSK (Proxy :: Proxy Text)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/SmallKey/Tests.hs
@@ -10,10 +10,10 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
--- NOTE: This tests defer the type errors that would other wise prevent
--- the following 'allKeys' instances from being called (or defined).
-{-# OPTIONS_GHC -fdefer-type-errors #-}
 {-# OPTIONS_GHC -Wno-deferred-type-errors #-}
+-- NOTE: These tests depend on deferring the type errors that would otherwise
+-- prevent some of the instances in this module from being derived.
+{-# OPTIONS_GHC -fdefer-type-errors #-}
 
 module Test.Consensus.Genesis.TestSuite.SmallKey.Tests (tests) where
 
@@ -24,49 +24,102 @@ import           Test.Consensus.Genesis.TestSuite.SmallKey
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-data UnitSumType = L () | R ()
-  deriving stock (Eq, Ord, Generic)
-  deriving SmallKey via Generically UnitSumType
+{-------------------------------------------------------------------------------
+  Types for testing SmallKey instances
+-------------------------------------------------------------------------------}
 
-data UnitProductType = P () ()
-  deriving stock (Eq, Ord, Generic)
-  deriving SmallKey via Generically UnitProductType
+data Empty
+  deriving stock Generic
+  deriving SmallKey via Generically Empty
 
-data IntUnaryType = U Int
-  deriving stock (Eq, Ord, Generic)
-  deriving SmallKey via Generically IntUnaryType
+data Unit = Unit
+  deriving stock (Eq, Generic)
+  deriving SmallKey via Generically Unit
 
--- | Contains a unit test for the correct derivation of a simple instance and
--- one corresponding to each black-listing strategy:
+data Single x = S x
+  deriving stock (Eq, Generic)
+  deriving SmallKey via Generically (Single x)
+
+data Enumeration = A | B | C
+  deriving stock (Eq, Bounded, Enum, Generic)
+  deriving SmallKey via Generically Enumeration
+
+data Sum x y = L x | R y
+  deriving stock (Eq, Generic)
+  deriving SmallKey via Generically (Sum x y)
+
+data Product x y = P x y
+  deriving stock (Eq, Generic)
+  deriving SmallKey via Generically (Product x y)
+
+data Outer = Inner Bool
+  deriving stock (Eq, Generic)
+  deriving SmallKey via Generically Outer
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+-- | Unit tests for the correct derivation of some simple ADT 'SmallKey'
+-- instances and a test asserting failure for each black-listing strategy:
 --
 -- 1. A type with a product on its generic representation.
 -- 2. A type with a explicitly black-listed field.
 --
 -- NOTE: These tests depend on @-fdefer-type-errors@ to run.
 --
--- TODO: Once the use of 'TypeError' changes to 'Unsatisfiable' in 'SmallKey' it
--- should be possible to 'assertError' the actual type error, and even
--- test a failing instance for
+-- TODO: Once the use of 'TypeError' is replaced with 'Unsatisfiable' in
+-- 'SmallKey' it should be possible to 'assertError' the /actual/ type error
+-- instead of the /unreacheable/ runtime error from 'getAllKeys', and write a
+-- test case for the forbidden directly recursive types, e.g.
 --
 -- @
--- data SimpleInfiniteType = Nil | More SimpleInfiniteType
+-- data DirectlyRecursive = Nil | More DirectlyRecursive
 --   deriving stock (Eq, Ord, Generic)
---   deriving SmallKey via Generically SimpleInfiniteType
+--   deriving SmallKey via Generically DirectlyRecursive
 -- @
 --
--- as we could avoid the evaluation of `allKeys` altogether.
+-- for which the corresponding test would not terminate trying to evaluate
+-- 'getAllKeys' otherwise.
 -- See TODO [BlackList].
---
 tests :: TestTree
-tests = testGroup "SmallKey"
-  [ testCase "A minimal sum type instance" $
-      assertBool "allKeys must be a permutation of the list of all values" $
-        elem (allKeys @UnitSumType) $ permutations [L (), R ()]
-  , testCase "A minimal product type instance is forbidden" $
-      assertError "unreachable: product type" $ allKeys @UnitProductType
-  , testCase "A minimal unary type instance with black-listed Int argument is forbidden" $
-      assertError "unreachable: NoSmallKey Int" $ allKeys @IntUnaryType
-  ]
+tests =
+  testGroup
+    "SmallKey"
+    [ testGroup
+        "generic instantiation of allowed types"
+        [ testCase "Empty" $
+            assertBool "must return the empty list" $
+              getAllKeys @Empty == []
+        , testCase "Unit" $
+            assertBool "must return a list with its only constructor" $
+              getAllKeys @Unit == [Unit]
+        , testCase "Single constructor" $
+            assertBool "must return a list with its only constructor" $
+              getAllKeys @(Single ()) == [S ()]
+        , testCase "Enumeration" $
+            assertBool "allKeys must be a permutation of the list of all values" $
+              elem (getAllKeys @Enumeration) $
+                permutations [minBound .. maxBound]
+        , testCase "Sum" $
+            assertBool "allKeys must be a permutation of the list of all values" $
+              elem (getAllKeys @(Sum () Bool)) $
+                permutations [L (), R False, R True]
+        , testCase "Nested key" $
+            assertBool "allKeys must be a permutation of the list of all values" $
+              elem (getAllKeys @Outer) $
+                permutations [Inner False, Inner True]
+        ]
+    , testGroup
+        "black-listed types"
+        [ testCase "Product" $
+            assertError "unreachable: product type" $
+              getAllKeys @(Product () ())
+        , testCase "Unary type with black-listed argument (Int)" $
+            assertError "unreachable: NoSmallKey Int" $
+              getAllKeys @(Single Int)
+        ]
+    ]
 
 assertError :: String -> a -> Assertion
 assertError expected val = do
@@ -76,4 +129,4 @@ assertError expected val = do
       | expected `isInfixOf` msg -> pure ()
       | otherwise -> assertFailure $ "Unexpected error message:\n" <> msg
     Right _ ->
-      assertFailure "Expected a type error, but computation succeeded"
+      assertFailure "Expected an error, but computation succeeded"

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite/Tests.hs
@@ -14,6 +14,6 @@ tests :: TestTree
 tests = testGroup "TestSuite"
   [ testCase "All test keys have distinct names" $
       assertBool "Test key names must be unique" $
-        not . anySame $ fmap toKey $ allKeys @All.TestKey
+        not . anySame $ fmap toKey $ getAllKeys @All.TestKey
   ,  Test.Consensus.Genesis.TestSuite.SmallKey.Tests.tests
   ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests.hs
@@ -25,8 +25,10 @@ import           Test.Tasty
 import           Test.Util.TestBlock (TestBlock)
 
 tests :: TestTree
-tests = testGroup "Genesis tests" $
-  [GDD.tests] <> toTestTree @TestBlock testSuite
+tests =
+  testGroup "Genesis tests" $
+    [GDD.tests] -- Tests with distinctive mechanisms, not (yet) integrated into a 'TestSuite'
+      <> toTestTree @TestBlock testSuite
 
 -- | Each value of this type uniquely corresponds to a Genesis test.
 data TestKey = Uniform !Uniform.TestKey

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -43,15 +43,15 @@ import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (* 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-adjustTestMaxSize :: Int -> Int
-adjustTestMaxSize = (`div` 5)
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = WithNoAdversariesAndOneScheduleForAllPeers
@@ -143,7 +143,8 @@ test_csj description adversariesFlag numHonestSchedules =
       let genForks = case adversariesFlag of
                       NoAdversaries   -> pure 0
                       WithAdversaries -> choose (2, 4)
-      mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+      mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
+
         ( disableBoringTimeouts <$> case numHonestSchedules of
             OneScheduleForAllPeers ->
               genChains genForks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -75,16 +75,25 @@ testSuite ::
   , Ord blk
   , Condense (Header blk)
   , Eq (Header blk)
-  ) => TestSuite blk TestKey
-testSuite = group "CSJ" $ newTestSuite $ \case
-  WithNoAdversariesAndOneScheduleForAllPeers ->
-    test_csj "adversary free: honest peers are synchronised" NoAdversaries OneScheduleForAllPeers
-  WithNoAdversariesAndOneSchedulePerHonestPeer ->
-    test_csj "adversary free: peers do their own thing" NoAdversaries OneSchedulePerHonestPeer
-  WithAdversariesAndOneScheduleForAllPeers ->
-    test_csj "with some adversaries: honest peers are synchronised" WithAdversaries OneScheduleForAllPeers
-  WithAdversariesAndOneSchedulePerHonestPeer ->
-    test_csj "with some adversaries: honest peers do their own thing" WithAdversaries OneSchedulePerHonestPeer
+  ) =>
+  TestSuite blk TestKey
+testSuite =
+  let keyToFlags :: TestKey -> (WithAdversariesFlag, NumHonestSchedulesFlag)
+      keyToFlags = \case
+        WithNoAdversariesAndOneScheduleForAllPeers -> (NoAdversaries, OneScheduleForAllPeers)
+        WithNoAdversariesAndOneSchedulePerHonestPeer -> (NoAdversaries, OneSchedulePerHonestPeer)
+        WithAdversariesAndOneScheduleForAllPeers -> (WithAdversaries, OneScheduleForAllPeers)
+        WithAdversariesAndOneSchedulePerHonestPeer -> (WithAdversaries, OneSchedulePerHonestPeer)
+      groupName key = case fst (keyToFlags key) of
+        NoAdversaries   -> "Happy path"
+        WithAdversaries -> "With some adversaries"
+      testDescription key = case snd (keyToFlags key) of
+        OneScheduleForAllPeers   -> "honest peers are synchronised"
+        OneSchedulePerHonestPeer -> "honest peers do their own thing"
+   in group "CSJ" $
+        grouping groupName $
+          newTestSuite $
+            \key -> uncurry (test_csj $ testDescription key) (keyToFlags key)
 
 -- | A flag to indicate if properties are tested with adversarial peers
 data WithAdversariesFlag = NoAdversaries | WithAdversaries

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -93,7 +93,7 @@ testSuite =
    in group "CSJ" $
         grouping groupName $
           newTestSuite $
-            \key -> uncurry (test_csj $ testDescription key) (keyToFlags key)
+            \key -> uncurry (testCsj $ testDescription key) (keyToFlags key)
 
 -- | A flag to indicate if properties are tested with adversarial peers
 data WithAdversariesFlag = NoAdversaries | WithAdversaries
@@ -123,7 +123,7 @@ data NumHonestSchedulesFlag = OneScheduleForAllPeers | OneSchedulePerHonestPeer
 -- jumpers takes its place and starts serving headers. This might lead to
 -- duplication of headers, but only in a window of @jumpSize@ slots near the tip
 -- of the chain.
-test_csj :: forall blk.
+testCsj :: forall blk.
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
@@ -131,7 +131,7 @@ test_csj :: forall blk.
   , Condense (Header blk)
   , Eq (Header blk)
   ) => String -> WithAdversariesFlag -> NumHonestSchedulesFlag -> ConformanceTest blk
-test_csj description adversariesFlag numHonestSchedules =
+testCsj description adversariesFlag numHonestSchedules =
   -- TODO(isovector): unsafePerformIO is not the right tool here, but making
   -- this is a big change otherwise, and I want to verify that this approach
   -- works before doing all the plumbing. Thankfully, this is /effectively/

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -74,6 +74,8 @@ import           Test.Util.PartialAccessors
 import           Test.Util.TersePrinting (terseHFragment, terseHWTFragment,
                      terseHeader)
 import           Test.Util.TestBlock (TestBlock, singleNodeTestConfig)
+import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
+                     adjustQuickCheckTests)
 
 -- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -104,7 +104,7 @@ testSuite = group "density disconnect" $ newTestSuite $ \case
 
 tests :: TestTree
 tests =
-  testGroup "density disconnect"
+  testGroup "gdd"
     [ testProperty "basic" prop_densityDisconnectStatic
     , testProperty "monotonicity" prop_densityDisconnectMonotonic
     ]

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -75,15 +75,15 @@ import           Test.Util.TersePrinting (terseHFragment, terseHWTFragment,
                      terseHeader)
 import           Test.Util.TestBlock (TestBlock, singleNodeTestConfig)
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (* 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-adjustTestMaxSize :: Int -> Int
-adjustTestMaxSize = (`div` 5)
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = TriggersChainSelection
@@ -104,10 +104,15 @@ testSuite = group "density disconnect" $ newTestSuite $ \case
 
 tests :: TestTree
 tests =
-  testGroup "gdd"
-    [ testProperty "basic" prop_densityDisconnectStatic
-    , testProperty "monotonicity" prop_densityDisconnectMonotonic
-    ]
+  let AdjustTestCount atc = adjustTestCount
+      AdjustMaxSize ams = adjustMaxSize
+   in adjustQuickCheckTests atc $
+        adjustQuickCheckMaxSize ams $
+          testGroup
+            "gdd"
+            [ testProperty "basic" prop_densityDisconnectStatic
+            , testProperty "monotonicity" prop_densityDisconnectMonotonic
+            ]
 
 branchTip :: AnchoredFragment TestBlock -> Tip TestBlock
 branchTip =
@@ -511,7 +516,8 @@ test_densityDisconnectTriggersChainSel ::
   , Ord blk
   ) => ConformanceTest blk
 test_densityDisconnectTriggersChainSel =
-  mkConformanceTest "re-triggers chain selection on disconnection" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "re-triggers chain selection on disconnection" (TestVersion 0) adjustTestCount adjustMaxSize
+
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let ps = lowDensitySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -100,7 +100,7 @@ testSuite ::
   , Ord blk
   ) => TestSuite blk TestKey
 testSuite = group "density disconnect" $ newTestSuite $ \case
-  TriggersChainSelection -> test_densityDisconnectTriggersChainSel
+  TriggersChainSelection -> testDensityDisconnectTriggersChainSel
 
 tests :: TestTree
 tests =
@@ -510,12 +510,12 @@ prop_densityDisconnectMonotonic =
 -- | Tests that a GDD disconnection re-triggers chain selection, i.e. when the current
 -- selection is blocked by LoE, and the leashing adversary reveals it is not dense enough,
 -- it gets disconnected and then the selection progresses.
-test_densityDisconnectTriggersChainSel ::
+testDensityDisconnectTriggersChainSel ::
   ( HasHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_densityDisconnectTriggersChainSel =
+testDensityDisconnectTriggersChainSel =
   mkConformanceTest "re-triggers chain selection on disconnection" (TestVersion 0) adjustTestCount adjustMaxSize
 
     ( do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -33,15 +33,15 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (* 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-adjustTestMaxSize :: Int -> Int
-adjustTestMaxSize = (`div` 5)
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = AdversaryDoesNotHitTimeouts
@@ -81,7 +81,8 @@ test_adversaryHitsTimeouts ::
   , IssueTestBlock blk
   ) => String -> Bool -> ConformanceTest blk
 test_adversaryHitsTimeouts description timeoutsEnabled =
-  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
+
       ( do
           gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
           let ps = delaySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -61,9 +61,9 @@ testSuite ::
   ) => TestSuite blk TestKey
 testSuite = group "LoE" $ newTestSuite $ \case
   AdversaryDoesNotHitTimeouts ->
-    test_adversaryHitsTimeouts "adversary does not hit timeouts" False
+    testAdversaryHitsTimeouts "adversary does not hit timeouts" False
   AdversaryHitsTimeouts ->
-    test_adversaryHitsTimeouts "adversary hits timeouts" True
+    testAdversaryHitsTimeouts "adversary hits timeouts" True
 
 -- | Tests that the selection advances in presence of the LoE when a peer is
 -- killed by something that is not LoE-aware, eg. the timeouts. This test
@@ -74,13 +74,13 @@ testSuite = group "LoE" $ newTestSuite $ \case
 -- the case where timeouts are disabled, we check that we do in fact remain
 -- stuck at the intersection between trunk and other chain.
 --
--- NOTE: Same as 'LoP.prop_delayAttack' with timeouts instead of LoP.
-test_adversaryHitsTimeouts ::
+-- NOTE: Same as 'LoP.testDelayAttack' with timeouts instead of LoP.
+testAdversaryHitsTimeouts ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
   ) => String -> Bool -> ConformanceTest blk
-test_adversaryHitsTimeouts description timeoutsEnabled =
+testAdversaryHitsTimeouts description timeoutsEnabled =
   mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
 
       ( do
@@ -88,6 +88,7 @@ test_adversaryHitsTimeouts description timeoutsEnabled =
           let ps = delaySchedule gtBlockTree
           pure $ gt $> ps
       )
+
       -- NOTE: Crucially, there must be timeouts for this test.
       ( defaultSchedulerConfig
           { scEnableChainSyncTimeouts = timeoutsEnabled,

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -77,13 +77,13 @@ testSuite ::
   , Ord blk
   ) => TestSuite blk TestKey
 testSuite = group "LoP" $ newTestSuite $ \case
-  WaitJustEnoughUntilEmpty -> test_wait "wait just enough" False
-  WaitTooMuchUntilEmpty -> test_wait "wait too much" True
-  WaitBehindForecastHorizon -> test_waitBehindForecastHorizon
-  ServeJustFastEnough -> test_serve "serve just fast enough" False
-  ServeTooSlow -> test_serve "serve too slow" True
-  DelayAttackSucceeds -> test_delayAttack "delaying attack succeeds without LoP" False
-  DelayAttackFails -> test_delayAttack "delaying attack fails with LoP" True
+  WaitJustEnoughUntilEmpty -> testWait "wait just enough" False
+  WaitTooMuchUntilEmpty -> testWait "wait too much" True
+  WaitBehindForecastHorizon -> testWaitBehindForecastHorizon
+  ServeJustFastEnough -> testServe "serve just fast enough" False
+  ServeTooSlow -> testServe "serve too slow" True
+  DelayAttackSucceeds -> testDelayAttack "delaying attack succeeds without LoP" False
+  DelayAttackFails -> testDelayAttack "delaying attack fails with LoP" True
 
 -- | Simple test in which we connect to only one peer, who advertises the tip of
 -- the block tree trunk and then does nothing. If the given boolean,
@@ -92,12 +92,12 @@ testSuite = group "LoP" $ newTestSuite $ \case
 -- client. If @mustTimeout@ is @False@, then we wait not quite as long, so the
 -- LoP bucket should not be empty at the end of the test and we should observe
 -- no exception in the ChainSync client.
-test_wait ::
+testWait ::
   ( HasHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
-test_wait description mustTimeout =
+testWait description mustTimeout =
   mkConformanceTest description (TestVersion 0) adjustTestCount
 
     -- NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
@@ -145,12 +145,12 @@ test_wait description mustTimeout =
 -- then be disabled and that, therefore, one could wait forever in this state.
 -- We disable the timeouts and check that, indeed, the ChainSync client observes
 -- no exception.
-test_waitBehindForecastHorizon ::
+testWaitBehindForecastHorizon ::
   ( HasHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_waitBehindForecastHorizon =
+testWaitBehindForecastHorizon =
   mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustTestCound adjustMaxSize
 
     ( do
@@ -200,12 +200,12 @@ test_waitBehindForecastHorizon =
 -- We will have two versions of this test: one where we serve the @n-1@th block
 -- but succumb before serving the @n@th block, and one where we do manage to
 -- serve the @n@th block, barely.
-test_serve ::
+testServe ::
   ( HasHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
-test_serve description mustTimeout =
+testServe description mustTimeout =
   mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
 
     ( do
@@ -259,15 +259,15 @@ test_serve description mustTimeout =
         psMinEndTime = Time 0
       }
 
--- | Same as 'Test.Consensus.Genesis.LoE.test_adversaryHitsTimeouts'
+-- | Same as 'Test.Consensus.Genesis.LoE.testAdversaryHitsTimeouts'
 -- with LoP instead of timeouts.
-test_delayAttack ::
+testDelayAttack ::
   ( HasHeader blk
   , HasHeader (Header blk)
   , IssueTestBlock blk
   ) =>
   String -> Bool -> ConformanceTest blk
-test_delayAttack description lopEnabled =
+testDelayAttack description lopEnabled =
   mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
 
     ( do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -39,15 +39,15 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.PartialAccessors
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (* 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-adjustTestMaxSize :: Int -> Int
-adjustTestMaxSize = (`div` 5)
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = WaitJustEnoughUntilEmpty
@@ -98,14 +98,14 @@ test_wait ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_wait description mustTimeout =
-  mkConformanceTest description (TestVersion 0) adjustDesiredPasses
+  mkConformanceTest description (TestVersion 0) adjustTestCount
 
     -- NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
     -- significantly more time than the one that does. This is because the former
     -- does all the computation (serving the headers, validating them, serving the
     -- block, validating them) while the latter does nothing, because it timeouts
     -- before reaching the last tick of the point schedule.
-    (case mustTimeout of False -> adjustTestMaxSize; True -> id)
+    (case mustTimeout of False -> adjustMaxSize; True -> AdjustMaxSize id)
 
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
@@ -113,6 +113,7 @@ test_wait description mustTimeout =
             gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}
         pure $ gt' $> ps
     )
+
     -- NOTE: Crucially, there must not be timeouts for this test.
     (defaultSchedulerConfig {scEnableChainSyncTimeouts = False, scEnableLoP = True})
 
@@ -150,7 +151,8 @@ test_waitBehindForecastHorizon ::
   , Ord blk
   ) => ConformanceTest blk
 test_waitBehindForecastHorizon =
-  mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustTestCound adjustMaxSize
+
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let ps = dullSchedule (btTrunk gtBlockTree)
@@ -204,7 +206,8 @@ test_serve ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_serve description mustTimeout =
-  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
+
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
@@ -265,7 +268,8 @@ test_delayAttack ::
   ) =>
   String -> Bool -> ConformanceTest blk
 test_delayAttack description lopEnabled =
-  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
+
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -151,7 +151,7 @@ testWaitBehindForecastHorizon ::
   , Ord blk
   ) => ConformanceTest blk
 testWaitBehindForecastHorizon =
-  mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustTestCound adjustMaxSize
+  mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustTestCount adjustMaxSize
 
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -25,10 +25,15 @@ import qualified Test.Consensus.PointSchedule as Schedule
 import           Test.Tasty.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (`div` 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (`div` 10)
+
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize id
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = WithOneAdversary
@@ -63,7 +68,8 @@ test_withOneAdversary ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_withOneAdversary =
-   mkConformanceTest "one adversary" (TestVersion 0) adjustDesiredPasses id
+   mkConformanceTest "one adversary" (TestVersion 0) adjustTestCount adjustMaxSize
+
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -53,7 +53,7 @@ testSuite = group "long range attack" $ newTestSuite $ \case
   -- NOTE: We want to keep this test to show that Praos is vulnerable to this
   -- attack but Genesis is not. This requires to first fix it as mentioned
   -- below.
-  WithOneAdversary -> test_withOneAdversary
+  WithOneAdversary -> testWithOneAdversary
 
 -- | This test case features a long-range attack with one adversary. The honest
 -- peer serves the block tree trunk, while the adversary serves its own chain,
@@ -61,13 +61,13 @@ testSuite = group "long range attack" $ newTestSuite $ \case
 -- The adversary serves the chain more rapidly than the honest peer. We check at
 -- the end that the selection is honest. This property does not hold with Praos,
 -- but should hold with Genesis.
-test_withOneAdversary ::
+testWithOneAdversary ::
    forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   ) => ConformanceTest blk
-test_withOneAdversary =
+testWithOneAdversary =
    mkConformanceTest "one adversary" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -62,15 +62,15 @@ import           Test.Util.PartialAccessors
 import           Test.Util.QuickCheck (le)
 import           Text.Printf (printf)
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-adjustDesiredPasses :: Int -> Int
-adjustDesiredPasses = (* 10)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (* 10)
 
 -- | Default adjustment of max test case size.
 -- Can be set individually on each test definition.
-adjustTestMaxSize :: Int -> Int
-adjustTestMaxSize = (`div` 5)
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize (`div` 5)
 
 -- | Each value of this type uniquely corresponds to a test defined in this module.
 data TestKey = BlockFetchLeashingAttack
@@ -176,7 +176,7 @@ test_serveAdversarialBranches ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_serveAdversarialBranches =
-  mkConformanceTest "serve adversarial branches" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "serve adversarial branches" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
@@ -244,7 +244,7 @@ test_leashingAttackStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackStalling =
-  mkConformanceTest "stalling leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "stalling leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
@@ -297,7 +297,7 @@ test_leashingAttackTimeLimited :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackTimeLimited =
-  mkConformanceTest "time limited leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "time limited leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
@@ -387,7 +387,7 @@ test_loeStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_loeStalling =
-  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt <- genChains (QC.choose (1, 4))
                 `enrichedWith`
@@ -432,7 +432,9 @@ test_downtime ::
   , Ord blk
   ) => ConformanceTest blk
 test_downtime =
-  mkConformanceTest "the node is shut down and restarted after some time" (TestVersion 0) adjustDesiredPasses (adjustTestMaxSize . const 10)
+  mkConformanceTest "the node is shut down and restarted after some time" (TestVersion 0) adjustTestCount
+
+    (let AdjustMaxSize ams = adjustMaxSize in AdjustMaxSize $ ams . const 10)
 
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
@@ -476,7 +478,7 @@ test_blockFetchLeashingAttack :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_blockFetchLeashingAttack =
-  mkConformanceTest "block fetch leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "block fetch leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -98,12 +98,12 @@ testSuite ::
   , Ord blk
   ) => TestSuite blk TestKey
 testSuite = group "uniform" $ newTestSuite $ \case
-    BlockFetchLeashingAttack -> test_blockFetchLeashingAttack
-    Downtime -> test_downtime
-    LeashingAttackStalling -> test_leashingAttackStalling
-    LeashingAttackTimeLimited -> test_leashingAttackTimeLimited
-    LoeStalling -> test_loeStalling
-    ServeAdversarialBranches -> test_serveAdversarialBranches
+    BlockFetchLeashingAttack -> testBlockFetchLeashingAttack
+    Downtime -> testDowntime
+    LeashingAttackStalling -> testLeashingAttackStalling
+    LeashingAttackTimeLimited -> testLeashingAttackTimeLimited
+    LoeStalling -> testLoeStalling
+    ServeAdversarialBranches -> testServeAdversarialBranches
 
 -- | The conjunction of
 --
@@ -169,13 +169,13 @@ fromBlockPoint _                                      = Nothing
 
 -- | Tests that the immutable tip is not delayed and stays honest with the
 -- adversarial peers serving adversarial branches.
-test_serveAdversarialBranches ::
+testServeAdversarialBranches ::
   ( AF.HasHeader blk
   , GetHeader blk
   , Ord blk
   , IssueTestBlock blk
   ) => ConformanceTest blk
-test_serveAdversarialBranches =
+testServeAdversarialBranches =
   mkConformanceTest "serve adversarial branches" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
@@ -237,13 +237,13 @@ genUniformSchedulePoints gt = stToGen (uniformPoints pointsGeneratorParams (gtBl
 -- | Test that the leashing attacks do not delay the immutable tip.
 --
 -- See Note [Leashing attacks]
-test_leashingAttackStalling :: forall blk.
+testLeashingAttackStalling :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_leashingAttackStalling =
+testLeashingAttackStalling =
   mkConformanceTest "stalling leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
@@ -290,13 +290,13 @@ dropRandomPoints ps = do
 -- all of its ticks.
 --
 -- See Note [Leashing attacks]
-test_leashingAttackTimeLimited :: forall blk.
+testLeashingAttackTimeLimited :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_leashingAttackTimeLimited =
+testLeashingAttackTimeLimited =
   mkConformanceTest "time limited leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
@@ -380,13 +380,13 @@ headCallStack = \case
 
 -- | Test that enabling the LoE causes the selection to remain at
 -- the first fork intersection (keeping the immutable tip honest).
-test_loeStalling :: forall blk.
+testLoeStalling :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_loeStalling =
+testLoeStalling =
   mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt <- genChains (QC.choose (1, 4))
@@ -425,13 +425,13 @@ test_loeStalling =
 -- is greater than 11 seconds, and restarts it while only preserving the immutable DB after advancing the time.
 --
 -- This ensures that a user may shut down their machine while syncing without additional vulnerabilities.
-test_downtime ::
+testDowntime ::
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_downtime =
+testDowntime =
   mkConformanceTest "the node is shut down and restarted after some time" (TestVersion 0) adjustTestCount
 
     (let AdjustMaxSize ams = adjustMaxSize in AdjustMaxSize $ ams . const 10)
@@ -471,13 +471,13 @@ test_downtime =
 -- make progress.
 --
 -- See Note [Leashing attacks]
-test_blockFetchLeashingAttack :: forall blk.
+testBlockFetchLeashingAttack :: forall blk.
   ( AF.HasHeader blk
   , GetHeader blk
   , IssueTestBlock blk
   , Ord blk
   ) => ConformanceTest blk
-test_blockFetchLeashingAttack =
+testBlockFetchLeashingAttack =
   mkConformanceTest "block fetch leashing attack" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests.hs
@@ -25,9 +25,9 @@ tests :: TestTree
 tests = testGroup "PeerSimulator" $ toTestTree @TestBlock testSuite
 
 -- | Each value of this type uniquely corresponds to a basic functionality test.
-data TestKey = LinkedThreads LinkedThreads.TestKey
-             | Rollback Rollback.TestKey
-             | Timeouts Timeouts.TestKey
+data TestKey = LinkedThreads !LinkedThreads.TestKey
+             | Rollback !Rollback.TestKey
+             | Timeouts !Timeouts.TestKey
   deriving stock (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -57,19 +57,19 @@ testSuite ::
   , Eq blk
   ) => TestSuite blk TestKey
 testSuite = group "ChainSync kills BlockFetch" . newTestSuite $ \case
-  ChainSyncKillsBlockFetch -> test_chainSyncKillsBlockFetch
+  ChainSyncKillsBlockFetch -> testChainSyncKillsBlockFetch
 
 -- | Check that when the scheduled ChainSync server gets killed, it takes the
 -- BlockFetch one with it. For this, we rely on ChainSync timeouts: the
 -- ChainSync server serves just one header and then waits long enough to get
 -- disconnected. After that, we give a tick for the BlockFetch server to serve
 -- the corresponding block. We check that the block is not served.
-test_chainSyncKillsBlockFetch ::
+testChainSyncKillsBlockFetch ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , Eq blk
   ) => ConformanceTest blk
-test_chainSyncKillsBlockFetch =
+testChainSyncKillsBlockFetch =
   mkConformanceTest "ChainSync kills BlockFetch" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -33,6 +33,16 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleHeaderPoint,
                      scheduleTipPoint)
 import           Test.Util.Orphans.IOLike ()
 
+-- | Default adjustment of the required number of test runs.
+-- Can be set individually on each test definition.
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount id
+
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize id
+
 data TestKey = ChainSyncKillsBlockFetch
   deriving (Show, Eq, Ord, Generic)
   deriving SmallKey via Generically TestKey
@@ -60,7 +70,8 @@ test_chainSyncKillsBlockFetch ::
   , Eq blk
   ) => ConformanceTest blk
 test_chainSyncKillsBlockFetch =
-  mkConformanceTest "ChainSync kills BlockFetch" (TestVersion 0) id id
+  mkConformanceTest "ChainSync kills BlockFetch" (TestVersion 0) adjustTestCount adjustMaxSize
+
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)
     )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -34,10 +34,15 @@ import           Test.Consensus.PointSchedule.SinglePeer (SchedulePoint (..),
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 
--- | Default adjustment of required property test passes.
+-- | Default adjustment of the required number of test runs.
 -- Can be set individually on each test definition.
-desiredPasses :: Int -> Int
-desiredPasses = (`div` 2)
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (`div` 2)
+
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize id
 
 data TestKey = CanRollback | CannotRollback
   deriving stock (Show, Eq, Ord, Generic)
@@ -68,7 +73,8 @@ test_rollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_rollback =
-  mkConformanceTest "can rollback" (TestVersion 0) desiredPasses id
+  mkConformanceTest "can rollback" (TestVersion 0) adjustTestCount adjustMaxSize
+
     (do
         -- Create a block tree with @1@ alternative chain, such that we can rollback
         -- from the trunk to that chain.
@@ -96,7 +102,8 @@ test_cannotRollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_cannotRollback =
-  mkConformanceTest "cannot rollback" (TestVersion 0) desiredPasses id
+  mkConformanceTest "cannot rollback" (TestVersion 0) adjustTestCount adjustMaxSize
+
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule = rollbackSchedule (fromIntegral (unNonZero $ maxRollbacks gtSecurityParam) + 1) gtBlockTree})
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -60,19 +60,19 @@ testSuite ::
   , Eq blk
   ) => TestSuite blk TestKey
 testSuite = group "rollback" . newTestSuite $ \case
-  CanRollback -> test_rollback
-  CannotRollback -> test_cannotRollback
+  CanRollback -> testRollback
+  CannotRollback -> testCannotRollback
 
 -- | Tests that the selection of the node under test
 -- changes branches when sent a rollback to a block no older than 'k' blocks
 -- before the current selection.
-test_rollback ::
+testRollback ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , AF.HasHeader (Header blk)
   , Eq blk
   ) => ConformanceTest blk
-test_rollback =
+testRollback =
   mkConformanceTest "can rollback" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do
@@ -95,13 +95,13 @@ test_rollback =
 -- | Tests that the selection of the node under test *does
 -- not* change branches when sent a rollback to a block strictly older than 'k'
 -- blocks before the current selection.
-test_cannotRollback ::
+testCannotRollback ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , AF.HasHeader (Header blk)
   , Eq blk
   ) => ConformanceTest blk
-test_cannotRollback =
+testCannotRollback =
   mkConformanceTest "cannot rollback" (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -63,17 +63,17 @@ testSuite ::
   , Condense (Header blk)
   ) => TestSuite blk TestKey
 testSuite = group "timeouts" . newTestSuite $ \case
-  DoesTimeout -> test_timeouts "does time out" True
-  DoesNotTimeout -> test_timeouts "does not time out" False
+  DoesTimeout -> testTimeouts "does time out" True
+  DoesNotTimeout -> testTimeouts "does not time out" False
 
-test_timeouts ::
+testTimeouts ::
   ( IssueTestBlock blk
   , AF.HasHeader blk
   , AF.HasHeader (Header blk)
   , Condense (HeaderHash blk)
   , Condense (Header blk)
   ) => String -> Bool -> ConformanceTest blk
-test_timeouts description mustTimeout =
+testTimeouts description mustTimeout =
   mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -35,8 +35,15 @@ import           Test.Consensus.PointSchedule.SinglePeer (scheduleBlockPoint,
 import           Test.QuickCheck
 import           Test.Util.Orphans.IOLike ()
 
-desiredPasses :: Int -> Int
-desiredPasses = (`div` 10)
+-- | Default adjustment of the required number of test runs.
+-- Can be set individually on each test definition.
+adjustTestCount :: AdjustTestCount
+adjustTestCount = AdjustTestCount (`div` 10)
+
+-- | Default adjustment of max test case size.
+-- Can be set individually on each test definition.
+adjustMaxSize :: AdjustMaxSize
+adjustMaxSize = AdjustMaxSize id
 
 data TestKey = DoesTimeout
              | DoesNotTimeout
@@ -67,7 +74,7 @@ test_timeouts ::
   , Condense (Header blk)
   ) => String -> Bool -> ConformanceTest blk
 test_timeouts description mustTimeout =
-  mkConformanceTest description (TestVersion 0) desiredPasses id
+  mkConformanceTest description (TestVersion 0) adjustTestCount adjustMaxSize
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PointSchedule/Tests.hs
@@ -39,7 +39,7 @@ import           Test.Util.TestEnv
 tests :: TestTree
 tests =
     adjustQuickCheckTests (* 100) $
-    adjustOption (\(QuickCheckMaxSize n) -> QuickCheckMaxSize (n `div` 10)) $
+    adjustQuickCheckMaxSize (`div` 10) $
     testGroup "PointSchedule"
       [ testProperty "zipMany" prop_zipMany
       , testProperty "singleJumpTipPoints" prop_singleJumpTipPoints

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
@@ -158,7 +158,7 @@ genTestBlockTreeWithPointSchedule branchFactor = do
   pure (gtBlockTree genesisTest, schedule)
 
 genKey :: (SmallKey k) => QC.Gen k
-genKey = QC.elements allKeys
+genKey = QC.elements getAllKeys
 
 shrinkBlockTree :: (HasHeader blk) => BlockTree blk -> [BlockTree blk]
 shrinkBlockTree (BlockTree trunk branches) = mconcat


### PR DESCRIPTION
Backports from https://github.com/IntersectMBO/ouroboros-consensus/pull/1915

- Documentation updates + fixes
- `newtypes` for adjustment fields of `ConformanceTest`: `AdjustTestCount` and `AdjustMaxSize`
- Introduced `getAllKeys` function to hide the `SmallKey` class method `allKeys`
- Blacklisted more big type `SmallKey` instances (`Int`s, `Word`s and `Text`).
- Refactored `SmallKey` tests to extend case variety
- Recovered the former `TestTree` structure inside the `CSJ.testSuite`
   - Added `grouping` combinator to `TestSuite.hs`
- Changed snake_case `ConformanceTest`s names to camelCase
- Removed use of `RecordWildCards` in `Genesis.Setup.hs`
- Added version bound to `monoidal-containers`