### PR TITLE
Add `suiteKeys` to `TestSuite` API

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/TestSuite.hs
@@ -25,6 +25,7 @@ module Test.Consensus.Genesis.TestSuite (
   , group
   , mkTestSuite
   , newTestSuite
+  , suiteKeys
   , toTestTree
   ) where
 
@@ -124,6 +125,10 @@ group :: String -> TestSuite blk key -> TestSuite blk key
 group pfs (TestSuite m) = TestSuite $
   Map.map (\testData ->
              testData {tsPrefix = pfs : tsPrefix testData}) m
+
+-- | Produce the list of test keys contained in a 'TestSuite'.
+suiteKeys :: TestSuite blk key -> [key]
+suiteKeys (TestSuite m) = Map.keys m
 
 -- * Compile 'TestSuite' into a 'TestTree'
 


### PR DESCRIPTION
Isolated this change from #54. `suiteKeys` is required for `testgen list-classes` implementation from https://github.com/tweag/cardano-node/pull/28 to get the keys directly from the test suite abstraction.