### PR TITLE
Add test versions to ConformanceTests

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Setup.hs
@@ -11,6 +11,7 @@
 module Test.Consensus.Genesis.Setup (
     ConformanceTest (..)
   , module Test.Consensus.Genesis.Setup.GenChains
+  , TestVersion (..)
   , castHeaderHash
   , honestImmutableTip
   , mkConformanceTest
@@ -24,6 +25,7 @@ import           Control.Monad.Class.MonadAsync
 import           Control.Monad.IOSim (IOSim, runSimStrictShutdown)
 import           Control.Tracer (debugTracer, traceWith)
 import           Data.Maybe (mapMaybe)
+import           Data.Word (Word8)
 import           Ouroboros.Consensus.Block.Abstract (ChainHash (..),
                      ConvertRawHash, GetHeader, Header)
 import           Ouroboros.Consensus.Block.SupportsDiffusionPipelining
@@ -69,6 +71,11 @@ import           Test.Util.TestEnv (adjustQuickCheckMaxSize,
 import           Test.Util.Tracer (recordingTracerM)
 import           Text.Printf (printf)
 
+-- | The version of a 'ConformanceTest'. Used to ensure that the serialized
+-- representation of a 'ConformanceTest' agrees with the version in code.
+newtype TestVersion = TestVersion Word8
+  deriving (Eq, Ord, Show)
+
 -- | Contains all necessary data to run a 'GenesisTest'.
 -- It is defined to reify the testing infrastructure for
 -- the conformance @testgen@ executable.
@@ -87,11 +94,19 @@ data ConformanceTest blk = ConformanceTest
     -- ^ Adjust the default test case maximum size.
   , ctDescription :: String
     -- ^ A description for the test.
+  , ctVersion :: TestVersion
+    -- ^ A version for the test. Since we serialize references to
+    -- 'ConformanceTest's, the version is used to ensure the test on disk is
+    -- cromulent with the current code. The version must be incremented every
+    -- time the generator, shrinker, or configuration is changed.
   }
 
 mkConformanceTest ::
   (Testable prop)
   => String  -- ^ Test description.
+  -> TestVersion
+  -- ^ Test version. Please increment this value every time the generator,
+  -- shrinker or configuration is changed.
   -> (Int -> Int) -- ^ Transformation of the default desired test passes/successes.
   -> (Int -> Int) -- ^ Transformation of the default max test size.
   -> Gen (GenesisTestFull blk) -- ^ Test generator.
@@ -99,7 +114,7 @@ mkConformanceTest ::
   -> (GenesisTestFull blk -> StateView blk -> [GenesisTestFull blk]) -- ^ Result inspecting shrinker.
   -> (GenesisTestFull blk -> StateView blk -> prop) -- ^ Property on test result.
   -> ConformanceTest blk
-mkConformanceTest ctDescription ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
+mkConformanceTest ctDescription ctVersion ctDesiredPasses ctMaxSize ctGenerator ctSchedulerConfig ctShrinker mkProperty =
   let ctProperty = fmap property . mkProperty
    in ConformanceTest {..}
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/CSJ.hs
@@ -134,7 +134,7 @@ test_csj description adversariesFlag numHonestSchedules =
       let genForks = case adversariesFlag of
                       NoAdversaries   -> pure 0
                       WithAdversaries -> choose (2, 4)
-      mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
+      mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
         ( disableBoringTimeouts <$> case numHonestSchedules of
             OneScheduleForAllPeers ->
               genChains genForks

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/DensityDisconnect.hs
@@ -511,7 +511,7 @@ test_densityDisconnectTriggersChainSel ::
   , Ord blk
   ) => ConformanceTest blk
 test_densityDisconnectTriggersChainSel =
-  mkConformanceTest "re-triggers chain selection on disconnection" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "re-triggers chain selection on disconnection" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let ps = lowDensitySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoE.hs
@@ -81,7 +81,7 @@ test_adversaryHitsTimeouts ::
   , IssueTestBlock blk
   ) => String -> Bool -> ConformanceTest blk
 test_adversaryHitsTimeouts description timeoutsEnabled =
-    mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
       ( do
           gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
           let ps = delaySchedule gtBlockTree

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LoP.hs
@@ -98,7 +98,7 @@ test_wait ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_wait description mustTimeout =
-  mkConformanceTest description adjustDesiredPasses
+  mkConformanceTest description (TestVersion 0) adjustDesiredPasses
 
     -- NOTE: Running the test that must _not_ timeout (@prop_smoke False@) takes
     -- significantly more time than the one that does. This is because the former
@@ -150,7 +150,7 @@ test_waitBehindForecastHorizon ::
   , Ord blk
   ) => ConformanceTest blk
 test_waitBehindForecastHorizon =
-  mkConformanceTest "wait behind forecast horizon" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "wait behind forecast horizon" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let ps = dullSchedule (btTrunk gtBlockTree)
@@ -204,7 +204,7 @@ test_serve ::
   , Ord blk
   ) => String -> Bool -> ConformanceTest blk
 test_serve description mustTimeout =
-  mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 0)
         let lbpRate = borderlineRate (AF.length (btTrunk gtBlockTree))
@@ -265,7 +265,7 @@ test_delayAttack ::
   ) =>
   String -> Bool -> ConformanceTest blk
 test_delayAttack description lopEnabled =
-  mkConformanceTest description adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest description (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
     ( do
         gt@GenesisTest {gtBlockTree} <- genChains (pure 1)
         let gt' = gt {gtLoPBucketParams = LoPBucketParams {lbpCapacity = 10, lbpRate = 1}}

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/LongRangeAttack.hs
@@ -63,7 +63,7 @@ test_withOneAdversary ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_withOneAdversary =
-  mkConformanceTest "one adversary" adjustDesiredPasses id
+   mkConformanceTest "one adversary" (TestVersion 0) adjustDesiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain.
         gt@GenesisTest{gtBlockTree} <- genChains (pure 1)

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Genesis/Tests/Uniform.hs
@@ -176,7 +176,7 @@ test_serveAdversarialBranches ::
   , IssueTestBlock blk
   ) => ConformanceTest blk
 test_serveAdversarialBranches =
-  mkConformanceTest "serve adversarial branches" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "serve adversarial branches" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genUniformSchedulePoints)
 
@@ -244,7 +244,7 @@ test_leashingAttackStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackStalling =
-  mkConformanceTest "stalling leashing attack" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "stalling leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genLeashingSchedule)
 
@@ -297,7 +297,7 @@ test_leashingAttackTimeLimited :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_leashingAttackTimeLimited =
-  mkConformanceTest "time limited leashing attack" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "time limited leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
 
     (genChains (QC.choose (1, 4)) `enrichedWith` genTimeLimitedSchedule)
 
@@ -387,7 +387,7 @@ test_loeStalling :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_loeStalling =
-  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "the LoE stalls the chain, but the immutable tip is honest" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
 
     (do gt <- genChains (QC.choose (1, 4))
                 `enrichedWith`
@@ -432,7 +432,7 @@ test_downtime ::
   , Ord blk
   ) => ConformanceTest blk
 test_downtime =
-  mkConformanceTest "the node is shut down and restarted after some time" adjustDesiredPasses (adjustTestMaxSize . const 10)
+  mkConformanceTest "the node is shut down and restarted after some time" (TestVersion 0) adjustDesiredPasses (adjustTestMaxSize . const 10)
 
     (genChains (QC.choose (1, 4)) `enrichedWith` \ gt ->
       ensureScheduleDuration gt <$> stToGen (uniformPoints (pointsGeneratorParams gt) (gtBlockTree gt)))
@@ -476,7 +476,7 @@ test_blockFetchLeashingAttack :: forall blk.
   , Ord blk
   ) => ConformanceTest blk
 test_blockFetchLeashingAttack =
-  mkConformanceTest "block fetch leashing attack" adjustDesiredPasses adjustTestMaxSize
+  mkConformanceTest "block fetch leashing attack" (TestVersion 0) adjustDesiredPasses adjustTestMaxSize
 
     (genChains (pure 0) `enrichedWith` genBlockFetchLeashingSchedule)
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/LinkedThreads.hs
@@ -60,7 +60,7 @@ test_chainSyncKillsBlockFetch ::
   , Eq blk
   ) => ConformanceTest blk
 test_chainSyncKillsBlockFetch =
-  mkConformanceTest "ChainSync kills BlockFetch" id id
+  mkConformanceTest "ChainSync kills BlockFetch" (TestVersion 0) id id
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)
     )

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Rollback.hs
@@ -68,7 +68,7 @@ test_rollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_rollback =
-  mkConformanceTest "can rollback" desiredPasses id
+  mkConformanceTest "can rollback" (TestVersion 0) desiredPasses id
     (do
         -- Create a block tree with @1@ alternative chain, such that we can rollback
         -- from the trunk to that chain.
@@ -96,7 +96,7 @@ test_cannotRollback ::
   , Eq blk
   ) => ConformanceTest blk
 test_cannotRollback =
-  mkConformanceTest "cannot rollback" desiredPasses id
+  mkConformanceTest "cannot rollback" (TestVersion 0) desiredPasses id
     (do gt@GenesisTest{gtSecurityParam, gtBlockTree} <- genChains (pure 1)
         pure gt {gtSchedule = rollbackSchedule (fromIntegral (unNonZero $ maxRollbacks gtSecurityParam) + 1) gtBlockTree})
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/PeerSimulator/Tests/Timeouts.hs
@@ -67,7 +67,7 @@ test_timeouts ::
   , Condense (Header blk)
   ) => String -> Bool -> ConformanceTest blk
 test_timeouts description mustTimeout =
-  mkConformanceTest description desiredPasses id
+  mkConformanceTest description (TestVersion 0) desiredPasses id
 
     (do gt@GenesisTest{gtBlockTree} <- genChains (pure 0)
         pure $ enableMustReplyTimeout $ gt $> dullSchedule (btTrunk gtBlockTree)


### PR DESCRIPTION
# Description

This PR adds a `TestVersion` that we can use to ensure serialized conformance tests agree with their in-code representations.

Closes https://github.com/tweag/cardano-conformance-testing-of-consensus/issues/109