### PR TITLE
Remove block tree from serialized test cases

### DIFF
--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize.hs
@@ -14,568 +14,84 @@
 module Test.Consensus.Serialize (
     -- * JSON serialization for test cases
     -- $intro
-    -- $howitworks
-    AnchoredFork (..)
-  , BlockId (..)
-  , BlockRep (..)
-  , ForkNo (..)
-  , FormatVersion (..)
-  , KnownBlocks (..)
-  , KnownForks (..)
-  , ReifiedBlockTree (..)
+    FormatVersion (..)
   , ReifiedTestCase (..)
   , Seed (..)
   , TestVersion (..)
-  , deserializeReifiedTestCase
-  , fromReifiedBlockTree
-  , fromReifiedPointSchedule
-  , fromReifiedTestCase
-  , getBlockRep
-  , getBlockReps
   , serializeReifiedTestCase
-  , toReifiedBlockTree
-  , toReifiedPointSchedule
-  , toReifiedTestCase
   ) where
 
-import           Cardano.Slotting.Slot (SlotNo (..))
-import           Control.Monad (foldM)
-import           Control.Monad.State (MonadState (..), runState)
 import           Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Types as Aeson
-import           Data.Functor ((<&>))
-import qualified Data.Map as M
 import           Data.Scientific (toBoundedInteger)
 import qualified Data.Text as T
-import           Data.Word (Word64)
-import qualified Ouroboros.Network.AnchoredFragment as AF
-import qualified Ouroboros.Network.Block as AF
-import           Test.Consensus.BlockTree
-import           Test.Consensus.Genesis.Setup.GenChains (IssueTestBlock (..))
-import           Test.Consensus.Genesis.ShrinkIndex
-import           Test.Consensus.PointSchedule
+import           Test.Consensus.Genesis.ShrinkIndex (ShrinkIndex, path)
 import qualified Test.QuickCheck as QC
 import           Test.QuickCheck.Random
 import           Text.Read (readMaybe)
 
 -- $intro
--- This module implements JSON serialization for consensus test cases. The
--- interface comprises:
 --
---   - 'ReifiedTestCase': a parameterized representation of a single
---     test case.
---   - 'serializeReifiedTestCase' and 'deserializeReifiedTestCase': functions
---     for converting between 'ReifiedTestCase' and 'Aeson.Value'.
---   - 'fromReifiedTestCase' and 'toReifiedTestCase': functions for converting
---     between a 'ReifiedTestCase' and a concrete test case type of your choice.
---
--- The JSON format is meant to be as stable as possible under changes to
--- test case generation. This is achieved via a test version number and
--- a serialization format version number, both of which are included in the JSON.
+-- This module implements JSON serialization for consensus test cases. Every
+-- @ConsensusTest@ has a canonical test case generator and shrinker, so we can
+-- get away with representing a test case as a seed for running @Gen@ computations
+-- and a path into the shrink tree. We also include a test key to identify which
+-- consensus test the data corresponds to, and a test version to allow for backward
+-- compatible updates to the generators, shrinkers, and properties.
 
--- $howitworks
--- We could have added Generic instances to everything and derived ToJSON/FromJSON.
--- That is not ideal however; first because generated test cases contain a lot of
--- redundant information (a LOT). Second, because this would tie the serialization
--- format to the internal representation, making it difficult to change both. We
--- expect serialized test cases to persist beyond a single run, so the format needs
--- to be stable under refactorings.
---
--- This implementation instead uses custom JSON instances, a simplified model of the
--- block tree that only includes the trunk and branch suffixes, and a representation
--- of blocks that only includes the data necessary to issue them in order.
+-- | A uniquely identified consensus test case.
+data ReifiedTestCase key = ReifiedTestCase
+  { rtcTestKey     :: key
+  -- ^ A key used by the test runner to identify a @ConsensusTest@.
 
--- | A fully concrete consensus test case, suitable for serialization.
---
--- It looks like this type is parameterized over the block type (and it is),
--- but this is only for the sake of the functor instance. We will only ever
--- serialize block summaries ('BlockRep') since that is all the consensus
--- tests need.
-data ReifiedTestCase key u = ReifiedTestCase
-  { rtcTestKey       :: key
-  -- ^ A key used by the test runner to identify a test or group of tests.
-
-  , rtcTestVersion   :: TestVersion
+  , rtcTestVersion :: TestVersion
   -- ^ Since serialized tests can exist beyond a single run, and tests can
   -- change over time, we need a way for the test case to specify which version
   -- of the test it was generated for.
 
-  , rtcBlockTree     :: ReifiedBlockTree u
-  -- ^ The block tree is represented as a trunk and a list of branches,
-  -- oldest nodes first.
-
-  , rtcPointSchedule :: PointSchedule BlockId
-
-  , rtcShrinkIndex   :: ShrinkIndex
+  , rtcShrinkIndex :: ShrinkIndex
   -- ^ Used for specifying a shrink of the generated test case.
 
-  , rtcSeed          :: Seed
-  -- ^ Used for replaying tests.
-  } deriving (Eq, Show, Functor, Foldable, Traversable)
+  , rtcSeed        :: Seed
+  -- ^ Used for deterministically generating test cases.
+  } deriving (Eq, Show)
+
+instance (QC.Arbitrary key) => QC.Arbitrary (ReifiedTestCase key) where
+  arbitrary = do
+    rtcTestKey <- QC.arbitrary
+    rtcTestVersion <- QC.arbitrary
+    rtcShrinkIndex <- fmap (path . fmap QC.getNonNegative) QC.arbitrary
+    rtcSeed <- fmap Seed QC.arbitrary
+    pure ReifiedTestCase {..}
 
 serializeReifiedTestCase
   :: (Aeson.ToJSON key)
   => FormatVersion
-  -> ReifiedTestCase key BlockRep
+  -> ReifiedTestCase key
   -> Aeson.Value
 serializeReifiedTestCase fmtVersion testCase = Aeson.object
   [ "formatVersion" .= fmtVersion
   , "key" .= Aeson.toJSON (rtcTestKey testCase)
   , "testVersion" .= rtcTestVersion testCase
-  , "blockTree" .= rtcBlockTree testCase
-  , "pointSchedule" .= rtcPointSchedule testCase
   , "shrinkIndex" .= rtcShrinkIndex testCase
   , "seed" .= rtcSeed testCase
   ]
 
-deserializeReifiedTestCase
-  :: (Aeson.FromJSON key)
-  => Aeson.Value -> Aeson.Parser (ReifiedTestCase key BlockRep)
-deserializeReifiedTestCase = Aeson.withObject "ReifiedTestCase" $ \obj -> do
-  fmtVersion <- obj .: "formatVersion"
-  case fmtVersion of
-    FormatVersionOne -> do
-      -- Currently we only have one format version.
-      rtcTestKey <- obj .: "key"
-      rtcTestVersion <- obj .: "testVersion"
-      rtcBlockTree <- obj .: "blockTree"
-      rtcPointSchedule <- obj .: "pointSchedule"
-      rtcShrinkIndex <- obj .: "shrinkIndex"
-      rtcSeed <- obj .: "seed"
-      pure ReifiedTestCase {..}
-
-instance (Aeson.ToJSON key) => Aeson.ToJSON (ReifiedTestCase key BlockRep) where
+instance (Aeson.ToJSON key) => Aeson.ToJSON (ReifiedTestCase key) where
+  -- If the default format version changes, update this.
   toJSON = serializeReifiedTestCase FormatVersionOne
 
-instance (Aeson.FromJSON key) => Aeson.FromJSON (ReifiedTestCase key BlockRep) where
-  parseJSON = deserializeReifiedTestCase
-
--- | Construct a 'ReifiedTestCase' from a concrete test case.
-toReifiedTestCase
-  :: (AF.HasHeader blk, Show blk)
-  => key -> TestVersion -> BlockTree blk -> PointSchedule blk -> ShrinkIndex -> Seed
-  -> ReifiedTestCase key BlockRep
-toReifiedTestCase key testVersion blockTree pointSchedule shrinkIndex seed =
-  let
-    (reifiedBlockTree, knownForks) = toReifiedBlockTree blockTree
-    reifiedPointSchedule = toReifiedPointSchedule knownForks pointSchedule
-  in ReifiedTestCase
-    { rtcTestKey = key
-    , rtcTestVersion = testVersion
-    , rtcBlockTree = reifiedBlockTree
-    , rtcPointSchedule = reifiedPointSchedule
-    , rtcShrinkIndex = shrinkIndex
-    , rtcSeed = seed
-    }
-
--- | Deconstruct a @ReifiedTestCase@ into a type of your choice using a continuation.
--- This decouples serialization from the specific test case type. If it helps you can
--- think of this as a fold.
-fromReifiedTestCase
-  :: forall blk key u. (AF.HasHeader blk, IssueTestBlock blk, Show blk)
-  => TestBlockContext blk
-  -> (key -> TestVersion -> BlockTree blk -> PointSchedule blk -> ShrinkIndex -> Seed -> u)
-  -> ReifiedTestCase key BlockRep -> Either String u
-fromReifiedTestCase ctx f ReifiedTestCase{..} = do
-  (blockTree, knownBlocks) <- fromReifiedBlockTree ctx rtcBlockTree
-  pointSchedule <- fromReifiedPointSchedule knownBlocks rtcPointSchedule
-  pure $ f rtcTestKey rtcTestVersion blockTree pointSchedule rtcShrinkIndex rtcSeed
-
-
-
--- Representation of Blocks --
-------------------------------
-
--- | Representation of a block within a block tree. Since consensus tests do
--- not care about the contents of blocks, we only need enough information to
--- reconstruct the block tree using the methods in `IssueTestBlock` (and thus
--- do not otherwise care about the specific block type).
-data BlockRep = BlockRep
-  { brSlotGap :: SlotGap  -- ^ Number of slots lapsed since the previous issued block.
-  , brBlockNo :: AF.BlockNo
-  } deriving (Eq, Ord, Show)
-
-instance (Aeson.ToJSON BlockRep) where
-  toJSON BlockRep{ brSlotGap, brBlockNo } = Aeson.object
-    [ "slotGap" .= brSlotGap
-    , "blockNo" .= brBlockNo
-    ]
-
-instance (Aeson.FromJSON BlockRep) where
-  parseJSON = Aeson.withObject "BlockRep" $ \v -> do
-    brSlotGap <- v .: "slotGap"
-    brBlockNo <- fmap AF.BlockNo $ v .: "blockNo"
-    pure BlockRep {..}
-
--- | There are two numbers relevant to slots running around. @SlotNo@ is an
--- ordinal number that identifies a slot. @SlotGap@ is a cardinal number that
--- counts how many slots have expired since the last issued block; this is
--- what IssueTestBlock needs to issue the next block.
-newtype SlotGap = SlotGap { unSlotGap :: Word64 }
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (Num, Real, Enum, Integral)
-
-instance Aeson.ToJSON SlotGap where
-  toJSON (SlotGap gap) = Aeson.Number (fromIntegral gap)
-
-instance Aeson.FromJSON SlotGap where
-  parseJSON = Aeson.withScientific "SlotGap" $ \sci ->
-    case toBoundedInteger sci of
-      Just v  -> pure (SlotGap v)
-      Nothing -> fail $ "Invalid SlotGap: " <> show sci
-
-offsetSlotNo :: SlotNo -> SlotGap -> SlotNo
-offsetSlotNo (SlotNo slot) (SlotGap gap) = SlotNo (slot + gap)
-
--- | Summarize a block as a @BlockRep@. @m@ is keeping track
--- of the most recently used slot number so we can compute the slot gap.
-getBlockRep
-  :: forall blk m. (AF.HasHeader blk, MonadState SlotNo m)
-  => blk -> m (BlockRep, blk)
-getBlockRep blk = do
-  SlotNo lastSlotNo <- get
-  let headers = AF.getHeaderFields blk
-      SlotNo currentSlotNo = AF.headerFieldSlot headers
-      slotGap = SlotGap (currentSlotNo - lastSlotNo)
-      blockNo = AF.headerFieldBlockNo headers
-  put (SlotNo currentSlotNo)
-  pure (BlockRep slotGap blockNo, blk)
-
-getBlockReps
-  :: forall blk t m. (AF.HasHeader blk, Traversable t, MonadState SlotNo m)
-  => t blk -> m (t (BlockRep, blk))
-getBlockReps = traverse getBlockRep
-
-
-
--- Representation of Block Trees --
------------------------------------
-
--- | Representation of the trunk and branches of a block tree as lists, oldest
--- nodes first. Meant to be as normalized as possible and efficient to convert
--- in both directions. Branches are represented as suffixes off the trunk, where
--- the anchor is a trunk node; this is enough to reconstruct the tree without
--- redundant information.
-data ReifiedBlockTree blk = ReifiedBlockTree
-  { rbtTrunk    :: AnchoredFork blk
-  , rbtBranches :: [AnchoredFork blk]
-  } deriving (Eq, Show, Functor, Foldable, Traversable)
-
-instance (Aeson.ToJSON blk) => Aeson.ToJSON (ReifiedBlockTree blk) where
-  toJSON ReifiedBlockTree{rbtTrunk, rbtBranches} =
-    Aeson.object
-      [ "trunk" .= rbtTrunk
-      , "branches" .= rbtBranches
-      ]
-
-instance (Aeson.FromJSON blk) => Aeson.FromJSON (ReifiedBlockTree blk) where
-  parseJSON = Aeson.withObject "ReifiedBlockTree" $ \v -> do
-    rbtTrunk <- v .: "trunk"
-    rbtBranches <- v .: "branches"
-    pure ReifiedBlockTree {..}
-
--- | @AnchoredFork@ is a simplified representation of an @AnchoredFragment@
--- as a list that also remembers its fork number. An anchor of 'Nothing'
--- represents the genesis.
---
--- INVARIANT: the blocks in 'forkBlocks' must be in order from oldest to newest,
--- and each block must be a valid successor of the previous block.
-data AnchoredFork u = AnchoredFork
-  { forkAnchor :: Maybe (SlotNo, u)
-  , forkBlocks :: [u] -- ^ Oldest first!
-  , forkNumber :: ForkNo
-  } deriving (Eq, Show, Functor, Foldable, Traversable)
-
-newtype ForkNo = ForkNo { unForkNo :: Int }
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (Num)
-
-instance Aeson.ToJSON u => Aeson.ToJSON (AnchoredFork u) where
-  toJSON AnchoredFork{forkAnchor, forkBlocks, forkNumber} = Aeson.object
-    [ "anchor" .= case forkAnchor of
-        Nothing -> Aeson.String "genesis"
-        Just (slotNo, rep) -> Aeson.object
-          [ "slotNo" .= slotNo
-          , "blockRep" .= rep
-          ]
-    , "blocks" .= forkBlocks
-    , "forkNo" .= unForkNo forkNumber
-    ]
-
-instance Aeson.FromJSON u => Aeson.FromJSON (AnchoredFork u) where
-  parseJSON = Aeson.withObject "AnchoredFork" $ \v -> do
-    forkAnchor <- do
-      val <- v .: "anchor"
-      case val of
-        Aeson.String s | s == "genesis" -> pure Nothing
-        Aeson.Object obj' -> do
-          slotNo <- obj' .: "slotNo"
-          blockRep <- obj' .: "blockRep"
-          pure $ Just (slotNo, blockRep)
-        _ -> fail "Invalid anchor format"
-    forkBlocks <- v .: "blocks"
-    forkNumber <- fmap ForkNo $ v .: "forkNo"
-    pure AnchoredFork {..}
-
-
-
--- Conversion between ReifiedBlockTree and BlockTree --
--------------------------------------------------------
-
--- | Convert a @BlockTree@ to a @ReifiedBlockTree@. This direction
--- turns slot numbers into slot gaps.
-toReifiedBlockTree
-  :: forall blk. (AF.HasHeader blk)
-  => BlockTree blk -> (ReifiedBlockTree BlockRep, KnownForks blk)
-toReifiedBlockTree (BlockTree trunk branches) =
-  let
-    (reifiedTrunk, knownForksTrunk) = anchoredFragmentToAnchoredForkOldestFirst (trunk, ForkNo 0)
-    (reifiedBranches, knownForksBranches) = unzip $ fmap anchoredFragmentToAnchoredForkOldestFirst
-      (zip (reverse $ fmap btbSuffix branches) (fmap ForkNo [1..]))
-  in
-    ( ReifiedBlockTree reifiedTrunk reifiedBranches
-    , mconcat (knownForksTrunk : knownForksBranches)
-    )
-  where
-    -- Represent an @AnchoredFragment@ as a list of @BlockRep@s, from oldest to
-    -- newest, plus the anchor. @BlockTreeBranch@es include a lot of redundant information;
-    -- all we need is the suffix of the branch (the part that is not shared with the trunk).
-    anchoredFragmentToAnchoredForkOldestFirst
-      :: (AF.AnchoredFragment blk, ForkNo) -> (AnchoredFork BlockRep, KnownForks blk)
-    anchoredFragmentToAnchoredForkOldestFirst (fragment, forkNo) =
-      let
-        anchor = getAnchorRep fragment
-        slotNo = case anchor of
-          Nothing           -> SlotNo 0
-          Just (slotNum, _) -> slotNum
-        -- The anchor's slot number is the one most recently used;
-        -- we use that to compute slot gaps for the fragment.
-        (fragment', _) = runState
-          (getBlockReps (AF.toOldestFirst fragment)) slotNo
-        knownForks = KnownForks $ M.fromList
-          [ (AF.headerFieldHash (AF.getHeaderFields blk), forkNo)
-          | (_, blk) <- fragment'
-          ]
-      in (AnchoredFork anchor (fmap fst fragment') forkNo, knownForks)
-
-    -- Summarize an anchored fragment's anchor.
-    getAnchorRep
-      :: AF.AnchoredFragment blk -> Maybe (SlotNo, BlockRep)
-    getAnchorRep fragment = case AF.anchor fragment of
-      AF.AnchorGenesis         -> Nothing
-      AF.Anchor slot _ blockNo -> Just (slot, BlockRep (SlotGap $ unSlotNo slot) blockNo)
-
--- | Blocks in a block tree are uniquely identified by their fork,
--- slot, and block numbers. @KnownBlocks@ maps these identifiers
--- to actual blocks.
-newtype KnownBlocks blk = KnownBlocks { unKnownBlocks :: M.Map BlockId blk }
-  deriving newtype (Semigroup, Monoid)
-
-
-
-newtype KnownForks blk = KnownForks { unKnownForks :: M.Map (AF.HeaderHash blk) ForkNo }
-
-deriving instance (Ord (AF.HeaderHash blk)) => Semigroup (KnownForks blk)
-deriving instance (Ord (AF.HeaderHash blk)) => Monoid (KnownForks blk)
-
-data BlockId = BlockId
-  { bidSlotNo  :: SlotNo
-  , bidBlockNo :: AF.BlockNo
-  , bidForkNo  :: ForkNo
-  } deriving (Eq, Ord, Show)
-
-instance Aeson.ToJSON BlockId where
-  toJSON BlockId { bidSlotNo, bidBlockNo, bidForkNo } = Aeson.object
-    [ "slotNo" .= bidSlotNo
-    , "blockNo" .= bidBlockNo
-    , "forkNo" .= unForkNo bidForkNo
-    ]
-
-instance Aeson.FromJSON BlockId where
-  parseJSON = Aeson.withObject "BlockId" $ \v -> do
-    bidSlotNo <- v .: "slotNo"
-    bidBlockNo <- fmap AF.BlockNo $ v .: "blockNo"
-    bidForkNo <- fmap ForkNo $ v .: "forkNo"
-    pure BlockId {..}
-
-lookupKnownBlock :: BlockId -> KnownBlocks blk -> Maybe blk
-lookupKnownBlock blockId (KnownBlocks m) = M.lookup blockId m
-
-insertKnownBlock :: BlockId -> blk -> KnownBlocks blk -> KnownBlocks blk
-insertKnownBlock blockId blk (KnownBlocks m) = KnownBlocks (M.insert blockId blk m)
-
-knownBlockIds :: KnownBlocks blk -> [BlockId]
-knownBlockIds (KnownBlocks m) = M.keys m
-
--- | Given a @ReifiedBlockTree@, attempt to reconstruct the original @BlockTree@
--- by issuing blocks in order. (Trunk first, then branches one by one.) To do this
--- we keep track of previously issued blocks in a @KnownBlocks@ map. Morally there
--- is a little state monad going on here, but we're just passing the state manually
--- to keep it simple. @KnownBlocks@ is needed for two reasons: to look up anchor
--- blocks when forking, and to rehydrate the point schedule.
---
--- This function is a nested fold:
---   * for each branch (including the trunk, which is special),
---     * for each block rep (including the anchor, which is special),
---       * issue the block and add it to the known block map
---     * then convert to an anchored fragment
---   * then try to assemble the converted trunk and branches to a block tree.
---
--- TODO: Unify this with the tree generation code in @genChains@.
-fromReifiedBlockTree
-  :: forall blk. (AF.HasHeader blk, IssueTestBlock blk, Show blk)
-  => TestBlockContext blk
-  -> ReifiedBlockTree BlockRep
-  -> Either String (BlockTree blk, KnownBlocks blk)
-fromReifiedBlockTree ctx ReifiedBlockTree{rbtTrunk, rbtBranches} = do
-  let
-    -- Construct the anchor of a chain. For non-trunk branches we
-    -- need to make sure the anchor has already been issued; it's
-    -- enough to convert the trunk first since all fork anchors
-    -- are there. For the trunk the anchor is always genesis.
-    makeAnchor
-      :: Maybe BlockId -> KnownBlocks blk -> Either String (AF.Anchor blk)
-    makeAnchor mAnchorId knownBlocks = case mAnchorId of
-      Nothing -> Right AF.AnchorGenesis
-      Just blockId -> case lookupKnownBlock blockId knownBlocks of
-        Just blk ->
-          let BlockId slotNo blockNo _ = blockId
-              hash = AF.headerFieldHash (AF.getHeaderFields blk)
-          in Right $ AF.Anchor slotNo hash blockNo
-        Nothing   -> Left $
-          "Failed to find anchor block for slot/blockNo: "
-          <> show blockId
-
-    issueNextBlockOnFork
-      :: ForkNo  -- Current fork number, needed to issue the first block on a branch
-      -> Maybe blk  -- Anchor block, if this fork is anchored to a block
-      -> ([blk], KnownBlocks blk, SlotNo)  -- Blocks issued so far (newest first) and known blocks
-      -> BlockRep  -- Block to be issued
-      -> Either String ([blk], KnownBlocks blk, SlotNo)
-    issueNextBlockOnFork forkNo mAnchorBlk (accBlocks, knownBlocks, lastSlotNo) rep = do
-      let
-        forkNo' = unForkNo forkNo
-        slotGap = brSlotGap rep
-        -- issueFirstBlock and issueSuccessorBlock treat their SlotNo
-        -- arguments differently; successor treats it like an offset
-        -- and adds one, and first treats it like an index.
-        slotNumber = offsetSlotNo lastSlotNo slotGap -- absolute slot number
-        slotSuccOffset = offsetSlotNo 0 (slotGap - 1) -- offset from last slot number minus one
-
-      blk <- pure $ case accBlocks of
-        []  -> case mAnchorBlk of
-          Nothing        -> issueFirstBlock ctx forkNo' slotNumber
-          Just anchorBlk -> issueSuccessorBlock ctx (Just forkNo') slotSuccOffset anchorBlk
-        h:_ -> issueSuccessorBlock ctx Nothing slotSuccOffset h
-
-      let blockId = BlockId slotNumber (brBlockNo rep) forkNo
-      pure
-        ( blk : accBlocks
-        , insertKnownBlock blockId blk knownBlocks
-        , slotNumber
-        )
-
-    issueBlocks
-      :: SlotNo  -- Last used slot number.
-      -> ForkNo  -- Current fork number
-      -> Maybe blk  -- Anchor block, if any
-      -- Blocks to be issued, oldest first, and the known blocks so far.
-      -> ([BlockRep], KnownBlocks blk)
-      -- Issued blocks, oldest first, and an updated map of blocks.
-      -> Either String ([blk], KnownBlocks blk)
-    issueBlocks lastSlotNo forkNo mAnchorBlk (reps, knownBlocks) = do
-      (blocks, blocksById, _) <-
-        foldM (issueNextBlockOnFork forkNo mAnchorBlk) ([], knownBlocks, lastSlotNo) reps
-      pure (reverse blocks, blocksById)
-
-    -- Issue a single fork (blocks plus anchor, the trunk is also a fork).
-    issueFork
-      -- The fork to process and the known blocks so far.
-      :: (AnchoredFork BlockRep, KnownBlocks blk)
-      -> Either String (AF.AnchoredFragment blk, KnownBlocks blk)
-    issueFork (AnchoredFork {forkAnchor, forkBlocks, forkNumber}, knownBlocks) = do
-      let
-        mAnchorBlockId :: Maybe BlockId
-        mAnchorBlockId = forkAnchor <&> \(slotNo, rep) ->
-          -- Anchor blocks are always on the trunk (aka fork zero)
-          BlockId slotNo (brBlockNo rep) (ForkNo 0)
-      anchor <- makeAnchor mAnchorBlockId knownBlocks
-      anchorBlock <- case mAnchorBlockId of
-        Nothing -> Right Nothing
-        Just blockId -> case lookupKnownBlock blockId knownBlocks of
-          Just blk -> Right (Just blk)
-          Nothing  -> Left $
-            "Failed to find anchor block for blockId: " <> show blockId
-      let lastSlotNo = maybe (SlotNo 0) fst forkAnchor
-      (issuedBlocks, knownBlocks') <-
-        issueBlocks lastSlotNo forkNumber anchorBlock (forkBlocks, knownBlocks)
-      let fragment = AF.fromOldestFirst anchor issuedBlocks
-      pure (fragment, knownBlocks')
-
-    issueNextBranch
-      :: ([AF.AnchoredFragment blk], KnownBlocks blk)
-      -> AnchoredFork BlockRep
-      -> Either String ([AF.AnchoredFragment blk], KnownBlocks blk)
-    issueNextBranch (fragments, knownBlocks) fork = do
-      (fragment, knownBlocks') <- issueFork (fork, knownBlocks)
-      pure (fragment : fragments, knownBlocks')
-
-  -- Issue the trunk blocks first so that the fork anchors will be in the known blocks map
-  (trunk, trunkBlocks) <- issueFork (rbtTrunk, mempty)
-  (branches, allBlocks) <- foldM issueNextBranch ([], trunkBlocks) (reverse rbtBranches)
-
-  -- @fromTrunkAndBranches@ is a smart constructor for @BlockTree@ that ensures
-  -- all the invariants are satisfied.
-  case fromTrunkAndBranches trunk branches of
-    Nothing -> Left $ mconcat
-      [ "Failed to decode block tree! Some branches do not intersect the trunk.\n"
-      , "Known block ids:\n", show (knownBlockIds allBlocks)
-      , "Trunk:\n", show trunk
-      , "Branches:\n", show branches
-      ]
-    Just bt -> Right (bt, allBlocks)
-
-
-
--- Point Schedule Conversion --
--------------------------------
-
-lookupKnownFork
-  :: (Ord (AF.HeaderHash blk))
-  => AF.HeaderHash blk -> KnownForks blk -> Maybe ForkNo
-lookupKnownFork blockHash (KnownForks m) = M.lookup blockHash m
-
--- | Replace the blocks in a point schedule with corresponding @BlockId@s.
-toReifiedPointSchedule
-  :: forall blk. (AF.HasHeader blk, Show blk)
-  => KnownForks blk -> PointSchedule blk -> PointSchedule BlockId
-toReifiedPointSchedule knownForks pointSchedule = pointSchedule <&> \blk ->
-  let
-    headers = AF.getHeaderFields blk
-    slotNo = AF.headerFieldSlot headers
-    blockNo = AF.headerFieldBlockNo headers
-    blockHash = AF.headerFieldHash headers
-  in case lookupKnownFork blockHash knownForks of
-      Just forkNo -> BlockId slotNo blockNo forkNo
-      Nothing -> error $ mconcat
-        [ "Failed to find fork number for block while reifying point schedule: "
-        , show (slotNo, blockNo)
-        , " block hash: "
-        , show blockHash
-        , " block: "
-        , show blk
-        ]
-
--- | During reconstruction of the block tree, we generated a map from block ids
--- to blocks. Use this with @traverse@ to repopulate the point schedule.
-fromReifiedPointSchedule
-  :: KnownBlocks blk -> PointSchedule BlockId
-  -> Either String (PointSchedule blk)
-fromReifiedPointSchedule blockTree = traverse $
-  \blockId -> case lookupKnownBlock blockId blockTree of
-    Just blk -> Right blk
-    Nothing  -> Left $ "Failed to find block id: " <> show blockId
+instance (Aeson.FromJSON key) => Aeson.FromJSON (ReifiedTestCase key) where
+  parseJSON = Aeson.withObject "ReifiedTestCase" $ \obj -> do
+    fmtVersion <- obj .: "formatVersion"
+    case fmtVersion of
+      FormatVersionOne -> do
+        -- Currently we only have one format version.
+        rtcTestKey <- obj .: "key"
+        rtcTestVersion <- obj .: "testVersion"
+        rtcShrinkIndex <- obj .: "shrinkIndex"
+        rtcSeed <- obj .: "seed"
+        pure ReifiedTestCase {..}
 
 
 

--- a/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
+++ b/ouroboros-consensus-diffusion/test/consensus-test/Test/Consensus/Serialize/Tests.hs
@@ -3,207 +3,68 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Consensus.Serialize.Tests (tests) where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKeyMap
 import qualified Data.Aeson.Types as Aeson
-import           Data.Foldable (toList)
-import           Data.List (foldl')
-import qualified Data.Map as M
-import           Data.Maybe (isJust)
 import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
-import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (BlockNo (..), HasHeader, SlotNo (..),
-                     StandardHash)
-import           Test.Consensus.BlockTree
-import           Test.Consensus.Genesis.Setup.GenChains (GenesisTest (..),
-                     IssueTestBlock (..), genChains)
-import           Test.Consensus.Genesis.ShrinkIndex
-import           Test.Consensus.Genesis.Tests.CSJ (genDuplicatedHonestSchedule)
-import           Test.Consensus.Genesis.Tests.Uniform
-                     (genBlockFetchLeashingSchedule, genLeashingSchedule,
-                     genTimeLimitedSchedule, genUniformSchedulePoints)
 import qualified Test.Consensus.Genesis.TestSuite.All as All
 import           Test.Consensus.Genesis.TestSuite.SmallKey
-import qualified Test.Consensus.PointSchedule as Schedule
 import           Test.Consensus.Serialize
 import qualified Test.QuickCheck as QC
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
-import           Test.Util.TestBlock (TestBlock)
 
 
 
--- TODO: Currently using `()` as a dummy key type; this should be replaced
--- with a proper key type.
 tests :: TestTree
 tests = testGroup "JSON Serialization"
-  [ testGroup "ReifiedTestCase () BlockRep"
+  [ testGroup "ReifiedTestCase ()"
     [ testProperty "toJSON . fromJSON . toJSON == toJSON" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        (prop_serialize_weak_inverse (Proxy @(ReifiedTestCase () BlockRep)))
+      QC.forAll QC.arbitrary
+        (prop_serialize_weak_inverse (Proxy @(ReifiedTestCase All.TestKey)))
     , testProperty "fromJSON . toJSON == id" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        (prop_deserialize_inverse (Proxy @(ReifiedTestCase () BlockRep)))
-    , testProperty "fromReifiedTestCase . toReifiedTestCase == id" $
-      QC.forAll (genConcreteTestCase branchFactor)
-        prop_fromReifiedTestCase_faithful_on_metadata
-    , testProperty "toReifiedTestCase preserves key/version/shrinkIndex/seed" $
-      QC.forAll (genConcreteTestCase branchFactor)
-        prop_toReifiedTestCase_preserves_metadata
+      QC.forAll QC.arbitrary
+        (prop_deserialize_inverse (Proxy @(ReifiedTestCase All.TestKey)))
     , testProperty "serializeReifiedTestCase emits exactly expected top-level keys" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        prop_serializeReifiedTestCase_emits_expected_keys
+      QC.forAll QC.arbitrary $
+        prop_serializeReifiedTestCase_emits_expected_keys @All.TestKey
     , testProperty "deserializeReifiedTestCase rejects missing required fields" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        prop_deserializeReifiedTestCase_rejects_missing_required_field
+      QC.forAll QC.arbitrary $
+        prop_deserializeReifiedTestCase_rejects_missing_required_field @All.TestKey
     , testProperty "deserializeReifiedTestCase rejects invalid required field types" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        prop_deserializeReifiedTestCase_rejects_bad_field_type
+      QC.forAll QC.arbitrary $
+        prop_deserializeReifiedTestCase_rejects_bad_field_type @All.TestKey
     , testProperty "deserializeReifiedTestCase ignores unknown fields" $
-      QC.forAll (genReifiedTestCase branchFactor)
-        prop_deserializeReifiedTestCase_ignores_unknown_fields
-    ]
-  , testGroup "ReifiedBlockTree"
-    [ testProperty "fromReifiedBlockTree . toReifiedBlockTree == id" $
-      QC.forAllShrink (genTestBlockTree branchFactor) shrinkBlockTree
-        prop_fromReifiedBlockTree_inverse
-    , testProperty "toReifiedBlockTree . fromReifiedBlockTree . toReifiedBlockTree == toReifiedBlockTree" $
-      QC.forAllShrink (genTestBlockTree branchFactor) shrinkBlockTree
-        prop_toReifiedBlockTree_weak_inverse
-    , testProperty "branch anchors always resolve to trunk ids" $
-      QC.forAllShrink (genTestBlockTree branchFactor) shrinkBlockTree
-        prop_anchor_correctness_invariants
-    , testProperty "fromReifiedBlockTree populates KnownBlocks for every reified block id" $
-      QC.forAllShrink (genTestBlockTree branchFactor) shrinkBlockTree
-        prop_fromReifiedBlockTree_knownBlocks_complete
-    , testProperty "fromReifiedBlockTree rejects dangling branch anchors" $
-      QC.forAllShrink (genTestBlockTree branchFactor) shrinkBlockTree
-        prop_fromReifiedBlockTree_rejects_dangling_anchor
-    ]
-  , testGroup "PointSchedule"
-    [ testProperty "toReifiedPointSchedule . fromReifiedPointSchedule . toReifiedPointSchedule == toReifiedPointSchedule" $
-      QC.forAll (genTestBlockTreeWithPointSchedule branchFactor) $
-        \(blockTree, pointSchedule) ->
-          prop_toReifiedPointSchedule_weak_inverse blockTree pointSchedule
-    , testProperty "fromReifiedPointSchedule rejects unknown block ids" $
-      QC.forAll (genTestBlockTreeWithPointSchedule branchFactor) $
-        \(blockTree, pointSchedule) ->
-          prop_fromReifiedPointSchedule_rejects_unknown_point blockTree pointSchedule
+      QC.forAll QC.arbitrary $
+        prop_deserializeReifiedTestCase_ignores_unknown_fields @All.TestKey
     ]
    , testGroup "TestKey" $
     [ testProperty "toJSON . fromJSON . toJSON == toJSON" $
       QC.forAll (genKey)
-        (prop_serialize_weak_inverse (Proxy @(All.TestKey)))
+        (prop_serialize_weak_inverse (Proxy @All.TestKey))
     , testProperty "fromJSON . toJSON == id" $
       QC.forAll (genKey)
-        (prop_deserialize_inverse (Proxy @(All.TestKey)))
+        (prop_deserialize_inverse (Proxy @All.TestKey))
     ]
   ]
-  where
-    branchFactor = pure 5
 
 
 
--- Generators and Shrinkers --
-------------------------------
-
-genReifiedTestCase
-  :: (QC.Arbitrary key)
-  => QC.Gen Word -> QC.Gen (ReifiedTestCase key BlockRep)
-genReifiedTestCase branchFactor = do
-  (rtcBlockTree, rtcPointSchedule) <- genTestReifiedBlockTreeWithPointSchedule branchFactor
-  rtcTestKey <- QC.arbitrary
-  rtcTestVersion <- QC.arbitrary
-  rtcShrinkIndex <- fmap (path . fmap QC.getNonNegative) QC.arbitrary
-  rtcSeed <- fmap Seed QC.arbitrary
-  pure ReifiedTestCase {..}
-
-genConcreteTestCase
-  :: QC.Gen Word
-  -> QC.Gen ((), TestVersion, BlockTree TestBlock, Schedule.PointSchedule TestBlock, ShrinkIndex, Seed)
-genConcreteTestCase branchFactor = do
-  (blockTree, pointSchedule) <- genTestBlockTreeWithPointSchedule branchFactor
-  testVersion <- QC.arbitrary
-  shrinkIndex <- fmap (path . fmap QC.getNonNegative) QC.arbitrary
-  seed <- fmap Seed QC.arbitrary
-  pure ((), testVersion, blockTree, pointSchedule, shrinkIndex, seed)
-
-genTestReifiedBlockTreeWithPointSchedule
-  :: QC.Gen Word
-  -> QC.Gen (ReifiedBlockTree BlockRep, Schedule.PointSchedule BlockId)
-genTestReifiedBlockTreeWithPointSchedule branchFactor = do
-  (blockTree, pointSchedule) <- genTestBlockTreeWithPointSchedule branchFactor
-  let (reifiedTree, knownForks) = toReifiedBlockTree blockTree
-  pure (reifiedTree, toReifiedPointSchedule knownForks pointSchedule)
-
-genTestBlockTree :: QC.Gen Word -> QC.Gen (BlockTree TestBlock)
-genTestBlockTree = fmap gtBlockTree . genChains
-
-genTestBlockTreeWithPointSchedule
-  :: QC.Gen Word
-  -> QC.Gen (BlockTree TestBlock, Schedule.PointSchedule TestBlock)
-genTestBlockTreeWithPointSchedule branchFactor = do
-  genesisTest <- genChains branchFactor
-  schedule <- QC.oneof $ fmap ($ genesisTest)
-    [ genDuplicatedHonestSchedule
-    , genLeashingSchedule
-    , genTimeLimitedSchedule
-    , genUniformSchedulePoints
-    , genBlockFetchLeashingSchedule
-    ]
-  pure (gtBlockTree genesisTest, schedule)
+-- Generators --
+----------------
 
 genKey :: (SmallKey k) => QC.Gen k
 genKey = QC.elements allKeys
 
-shrinkBlockTree :: (HasHeader blk) => BlockTree blk -> [BlockTree blk]
-shrinkBlockTree (BlockTree trunk branches) = mconcat
-  [ -- Shrink the branches first, if any. This avoids
-    -- removing trunk nodes to which branches are attached.
-    case branches of
-      [] -> []
-      _:_ -> do
-        -- Shrink the branch suffixes, and filter out any that become empty.
-        -- If all branches were shorter than the trunk before, then they still are.
-        branches' <- fmap (filter (shareAnchorButNoBlocksWith trunk) . filter (not . AF.null)) $
-          QC.shrinkList shrinkAnchoredFragment $ fmap btbSuffix branches
-        case fromTrunkAndBranches trunk branches' of
-          Nothing -> []
-          Just bt -> pure bt
-
-  , -- Shrink the trunk, removing any branches whose anchors are removed.
-    do
-      trunk' <- shrinkAnchoredFragment trunk
-      case fromTrunkAndBranches trunk' $ fmap btbSuffix branches of
-        Nothing -> []
-        Just bt ->
-          let
-              -- Filter out shrinks where the trunk is shorter than the longest branch.
-              BlockTree shrunkTrunk shrunkBranches = bt
-              trunkLength = AF.length shrunkTrunk
-              maxBranchLength = maximum (0 : fmap (AF.length . btbFull) shrunkBranches)
-            in case compare trunkLength maxBranchLength of
-              GT -> pure bt
-              _  -> []
-  ]
-
-shareAnchorButNoBlocksWith
-  :: (HasHeader blk) => AF.AnchoredFragment blk -> AF.AnchoredFragment blk -> Bool
-shareAnchorButNoBlocksWith fragment1 fragment2 =
-  case AF.intersect fragment1 fragment2 of
-    Nothing -> False
-    Just (prefix1, prefix2, _, _) -> min (AF.length prefix1) (AF.length prefix2) > 0
-
--- | If the fragment is not empty, drop the most recent block.
-shrinkAnchoredFragment
-  :: (HasHeader blk) => AF.AnchoredFragment blk -> [AF.AnchoredFragment blk]
-shrinkAnchoredFragment fragment = case AF.toNewestFirst fragment of
-  []     -> []
-  _:rest -> pure $ AF.fromNewestFirst (AF.anchor fragment) rest
+instance QC.Arbitrary (All.TestKey) where
+  arbitrary = genKey
 
 
 
@@ -266,188 +127,12 @@ prop_serialize_weak_inverse _ value =
         False -> QC.counterexample (jsonNotStableMsg json2) False
         True  -> QC.property True
 
--- | fromReifiedBlockTree . toReifiedBlockTree == id
-prop_fromReifiedBlockTree_inverse
-  :: forall blk. (Show blk, Eq blk, HasHeader blk, IssueTestBlock blk)
-  => BlockTree blk -> QC.Property
-prop_fromReifiedBlockTree_inverse blockTree = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reified, _) = toReifiedBlockTree blockTree
-    cannotConvertMsg err = mconcat
-      [ "Unable to convert from ReifiedBlockTree to BlockTree:\n"
-      , "BlockTree: ", show blockTree, "\n"
-      , "ReifiedBlockTree: ", show reified, "\n"
-      , "Error: ", err
-      ]
-  pure $ case fromReifiedBlockTree ctx reified of
-      Left err              -> QC.counterexample (cannotConvertMsg err) False
-      Right (blockTree', _) -> eqBlockTree blockTree blockTree'
 
--- Are two block trees equal?
-eqBlockTree
-  :: (StandardHash blk, Show blk, Eq blk)
-  => BlockTree blk -- ^ Actual value
-  -> BlockTree blk -- ^ Expected value
-  -> QC.Property
-eqBlockTree (BlockTree trunk1 branches1) (BlockTree trunk2 branches2) =
-  QC.conjoin
-    [ let
-        msg = mconcat
-          [ "Expected equal block trees, but the trunks do not match:\n"
-          , "Expected: ", show trunk2, "\n"
-          , "Actual: ", show trunk1, "\n"
-          ]
-      in QC.counterexample msg $ QC.property (trunk1 == trunk2)
-    , let
-        msg = mconcat
-          [ "Expected equal block trees, but the branches do not match:\n"
-          , "Expected: ", show branches2, "\n"
-          , "Actual: ", show branches1, "\n"
-          ]
-      in QC.counterexample msg $ QC.property (branches1 == branches2)
-    ]
-
--- | toReifiedBlockTree . fromReifiedBlockTree . toReifiedBlockTree == toReifiedBlockTree
-prop_toReifiedBlockTree_weak_inverse
-  :: forall blk. (Show blk, HasHeader blk, IssueTestBlock blk)
-  => BlockTree blk -> QC.Property
-prop_toReifiedBlockTree_weak_inverse blockTree = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reified1, _) = toReifiedBlockTree blockTree
-    cannotConvertMsg err = mconcat
-      [ "Unable to decode initial reified tree:\n"
-      , "Initial ReifiedBlockTree: ", show reified1, "\n"
-      , "Error: ", err
-      ]
-    unstableMsg reified2 = mconcat
-      [ "Reified tree not stable after round-trip:\n"
-      , "Initial: ", show reified1, "\n"
-      , "After:   ", show reified2
-      ]
-    fromReified1 :: Either String (BlockTree blk, KnownBlocks blk)
-    fromReified1 = fromReifiedBlockTree ctx reified1
-  pure $ case fromReified1 of
-      Left err               -> QC.counterexample (cannotConvertMsg err) False
-      Right (blockTree', _ ) ->
-        let (reified2, _) = toReifiedBlockTree blockTree'
-        in QC.counterexample (unstableMsg reified2) $ QC.property (reified1 == reified2)
-
--- | Every non-genesis branch anchor in a reified tree must refer to a trunk block id.
-prop_anchor_correctness_invariants
-  :: forall blk. (HasHeader blk)
-  => BlockTree blk -> QC.Property
-prop_anchor_correctness_invariants blockTree =
-  let
-    (reified@ReifiedBlockTree{rbtTrunk, rbtBranches}, _) = toReifiedBlockTree blockTree
-    trunkIds = Set.fromList (forkBlockIds rbtTrunk)
-    missingAnchors = flip map (zip [0..] rbtBranches) $ \(ix :: Int, branch) -> do
-      (slotNo, rep) <- forkAnchor branch
-      let anchorId = BlockId slotNo (brBlockNo rep) (ForkNo 0)
-      case Set.member anchorId trunkIds of
-        True  -> Nothing
-        False -> Just (ix, anchorId)
-    failures = [ x | Just x <- missingAnchors ]
-    msg = mconcat
-      [ "Found branch anchors not present in trunk block ids:\n"
-      , "Missing anchors: ", show failures, "\n"
-      , "Trunk ids: ", show (Set.toList trunkIds), "\n"
-      , "ReifiedBlockTree: ", show reified
-      ]
-  in QC.counterexample msg $ QC.property (null failures)
-
--- | toReifiedPointSchedule . fromReifiedPointSchedule . toReifiedPointSchedule == toReifiedPointSchedule
-prop_toReifiedPointSchedule_weak_inverse
-  :: forall blk.
-     (Show blk, HasHeader blk, IssueTestBlock blk)
-  => BlockTree blk -> Schedule.PointSchedule blk -> QC.Property
-prop_toReifiedPointSchedule_weak_inverse blockTree pointSchedule = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reifiedTree, knownForks) = toReifiedBlockTree blockTree
-    reifiedSchedule1 = toReifiedPointSchedule knownForks pointSchedule
-    cannotConvertTreeMsg err = mconcat
-      [ "Unable to decode reified block tree for point schedule test:\n"
-      , "BlockTree: ", show blockTree, "\n"
-      , "ReifiedBlockTree: ", show reifiedTree, "\n"
-      , "Error: ", err
-      ]
-    cannotConvertScheduleMsg err = mconcat
-      [ "Unable to decode reified point schedule:\n"
-      , "PointSchedule: ", show pointSchedule, "\n"
-      , "ReifiedPointSchedule: ", show reifiedSchedule1, "\n"
-      , "Error: ", err
-      ]
-    notStableMsg reifiedSchedule2 = mconcat
-      [ "Reified point schedule not stable after weak round-trip:\n"
-      , "Original: ", show reifiedSchedule1, "\n"
-      , "After:    ", show reifiedSchedule2
-      ]
-    fromReifiedTree :: Either String (BlockTree blk, KnownBlocks blk)
-    fromReifiedTree = fromReifiedBlockTree ctx reifiedTree
-  pure $ case fromReifiedTree of
-      Left err -> QC.counterexample (cannotConvertTreeMsg err) False
-      Right (_, knownBlocks) ->
-        case fromReifiedPointSchedule knownBlocks reifiedSchedule1 of
-          Left err -> QC.counterexample (cannotConvertScheduleMsg err) False
-          Right pointSchedule' ->
-            let (_, knownForks') = toReifiedBlockTree blockTree
-                reifiedSchedule2 = toReifiedPointSchedule knownForks' pointSchedule'
-            in QC.counterexample (notStableMsg reifiedSchedule2) $ QC.property (reifiedSchedule2 == reifiedSchedule1)
-
--- | The type of @fromReifiedTestCase@ takes a continuation that is used to construct
--- a concrete test case. Verify that the metadata passed to the continuation matches
--- that of the original test case.
-prop_fromReifiedTestCase_faithful_on_metadata
-  :: ((), TestVersion, BlockTree TestBlock, Schedule.PointSchedule TestBlock, ShrinkIndex, Seed)
-  -> QC.Property
-prop_fromReifiedTestCase_faithful_on_metadata (testKey, testVersion, blockTree, pointSchedule, shrinkIndex, seed) = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @TestBlock
-  let
-    reified = toReifiedTestCase testKey testVersion blockTree pointSchedule shrinkIndex seed
-    cannotConvertMsg err = mconcat
-      [ "Unable to reconstruct concrete test case from reified representation:\n"
-      , "Error: ", err, "\n"
-      , "ReifiedTestCase: ", show reified
-      ]
-    fromReified = fromReifiedTestCase ctx (,,,,,) reified
-  pure $ case fromReified of
-      Left err -> QC.counterexample (cannotConvertMsg err) False
-      Right (testKey', testVersion', blockTree', pointSchedule', shrinkIndex', seed') ->
-        let
-          (_, knownForks') = toReifiedBlockTree blockTree'
-          reifiedSchedule' = toReifiedPointSchedule knownForks' pointSchedule'
-        in QC.conjoin
-          [ QC.counterexample "test key changed after to/from reified conversion" $
-              QC.property (testKey == testKey')
-          , QC.counterexample "test version changed after to/from reified conversion" $
-              QC.property (testVersion == testVersion')
-          , eqBlockTree blockTree' blockTree
-          , QC.counterexample "reified point schedule changed after to/from reified conversion" $
-            QC.property (reifiedSchedule' == rtcPointSchedule reified)
-          , QC.counterexample "shrink index changed after to/from reified conversion" $
-              QC.property (shrinkIndex == shrinkIndex')
-          , QC.counterexample "seed changed after to/from reified conversion" $
-              QC.property (seed == seed')
-          ]
-
-prop_toReifiedTestCase_preserves_metadata
-  :: ((), TestVersion, BlockTree TestBlock, Schedule.PointSchedule TestBlock, ShrinkIndex, Seed)
-  -> QC.Property
-prop_toReifiedTestCase_preserves_metadata (testKey, testVersion, blockTree, pointSchedule, shrinkIndex, seed) =
-  let
-    reified = toReifiedTestCase testKey testVersion blockTree pointSchedule shrinkIndex seed
-  in QC.conjoin
-      [ QC.counterexample "rtcTestKey mismatch" $ QC.property (rtcTestKey reified == testKey)
-      , QC.counterexample "rtcTestVersion mismatch" $ QC.property (rtcTestVersion reified == testVersion)
-      , QC.counterexample "rtcShrinkIndex mismatch" $ QC.property (rtcShrinkIndex reified == shrinkIndex)
-      , QC.counterexample "rtcSeed mismatch" $ QC.property (rtcSeed reified == seed)
-      ]
 
 -- | Serialized test cases have the expected keys.
 prop_serializeReifiedTestCase_emits_expected_keys
-  :: ReifiedTestCase () BlockRep -> QC.Property
+  :: forall key. (Aeson.ToJSON key, Aeson.FromJSON key)
+  => ReifiedTestCase key -> QC.Property
 prop_serializeReifiedTestCase_emits_expected_keys reified =
   case serializeReifiedTestCase FormatVersionOne reified of
     Aeson.Object obj ->
@@ -457,8 +142,6 @@ prop_serializeReifiedTestCase_emits_expected_keys reified =
           [ "formatVersion"
           , "key"
           , "testVersion"
-          , "blockTree"
-          , "pointSchedule"
           , "shrinkIndex"
           , "seed"
           ]
@@ -472,7 +155,8 @@ prop_serializeReifiedTestCase_emits_expected_keys reified =
 
 -- | Deserializing a ReifiedTestCase with any required field missing should fail.
 prop_deserializeReifiedTestCase_rejects_missing_required_field
-  :: ReifiedTestCase () BlockRep -> QC.Property
+  :: forall key. (Aeson.FromJSON key, Aeson.ToJSON key, Show key)
+  => ReifiedTestCase key -> QC.Property
 prop_deserializeReifiedTestCase_rejects_missing_required_field reified =
   case serializeReifiedTestCase FormatVersionOne reified of
     Aeson.Object obj ->
@@ -484,8 +168,6 @@ prop_deserializeReifiedTestCase_rejects_missing_required_field reified =
       [ "formatVersion"
       , "key"
       , "testVersion"
-      , "blockTree"
-      , "pointSchedule"
       , "shrinkIndex"
       , "seed"
       ]
@@ -496,7 +178,7 @@ prop_deserializeReifiedTestCase_rejects_missing_required_field reified =
       -> QC.Property
     fieldMustFailWhenMissing obj field =
       let mutated = Aeson.Object $ AesonKeyMap.delete field obj
-      in case parseReifiedTestCaseValue mutated of
+      in case parseReifiedTestCaseValue @key mutated of
           Left _ -> QC.property True
           Right parsed -> QC.counterexample
             (mconcat
@@ -510,15 +192,14 @@ prop_deserializeReifiedTestCase_rejects_missing_required_field reified =
 -- | Deserializing a ReifiedTestCase with an invalid type
 -- for a required field should fail.
 prop_deserializeReifiedTestCase_rejects_bad_field_type
-  :: ReifiedTestCase () BlockRep -> QC.Property
+  :: forall key. (Aeson.FromJSON key, Aeson.ToJSON key, Show key)
+  => ReifiedTestCase key -> QC.Property
 prop_deserializeReifiedTestCase_rejects_bad_field_type reified =
   case serializeReifiedTestCase FormatVersionOne reified of
     Aeson.Object obj ->
       QC.conjoin $ fmap (mutationMustFail obj)
         [ ("formatVersion", Aeson.Bool True)
         , ("testVersion", Aeson.String "0.0")
-        , ("blockTree", Aeson.String "not-an-object")
-        , ("pointSchedule", Aeson.String "not-an-object")
         , ("shrinkIndex", Aeson.Bool True)
         , ("seed", Aeson.Number 0)
         ]
@@ -530,7 +211,7 @@ prop_deserializeReifiedTestCase_rejects_bad_field_type reified =
       -> QC.Property
     mutationMustFail obj (field, badValue) =
       let mutated = Aeson.Object $ AesonKeyMap.insert field badValue obj
-      in case parseReifiedTestCaseValue mutated of
+      in case parseReifiedTestCaseValue @key mutated of
           Left _ -> QC.property True
           Right parsed -> QC.counterexample
             (mconcat
@@ -544,13 +225,14 @@ prop_deserializeReifiedTestCase_rejects_bad_field_type reified =
 -- | Adding unknown JSON fields should not cause parsing to fail, and the
 -- unknown fields should be ignored.
 prop_deserializeReifiedTestCase_ignores_unknown_fields
-  :: ReifiedTestCase () BlockRep -> QC.Property
+  :: forall key. (Aeson.FromJSON key, Aeson.ToJSON key, Eq key, Show key)
+  => ReifiedTestCase key -> QC.Property
 prop_deserializeReifiedTestCase_ignores_unknown_fields reified =
   case serializeReifiedTestCase FormatVersionOne reified of
     Aeson.Object obj ->
       let
         mutated = Aeson.Object $ AesonKeyMap.insert "_unknownField" (Aeson.String "extra") obj
-      in case parseReifiedTestCaseValue mutated of
+      in case parseReifiedTestCaseValue @key mutated of
           Left err -> QC.counterexample
             ("Expected parse success with unknown field, got error: " <> err)
             False
@@ -563,142 +245,6 @@ prop_deserializeReifiedTestCase_ignores_unknown_fields reified =
             (QC.property (parsed == reified))
     value -> QC.counterexample ("Expected object JSON, got: " <> show value) False
 
--- | The KnownBlocks map produced by fromReifiedBlockTree should contain entries
--- for every block ID present in the block tree.
-prop_fromReifiedBlockTree_knownBlocks_complete
-  :: forall blk. (HasHeader blk, IssueTestBlock blk, Show blk)
-  => BlockTree blk -> QC.Property
-prop_fromReifiedBlockTree_knownBlocks_complete blockTree = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reified, _) = toReifiedBlockTree blockTree
-    expectedIds = Set.fromList $
-      concatMap forkBlockIds (rbtTrunk reified : rbtBranches reified)
-    cannotConvertMsg err = mconcat
-      [ "Unable to decode ReifiedBlockTree:\n"
-      , "ReifiedBlockTree: ", show reified, "\n"
-      , "Error: ", err
-      ]
-    fromReified :: Either String (BlockTree blk, KnownBlocks blk)
-    fromReified = fromReifiedBlockTree ctx reified
-  pure $ case fromReified of
-      Left err -> QC.counterexample (cannotConvertMsg err) False
-      Right (_, knownBlocks) ->
-        let
-          observedIds = Set.fromList (M.keys (unKnownBlocks knownBlocks))
-          missing = Set.toList (expectedIds Set.\\ observedIds)
-          msg = mconcat
-            [ "KnownBlocks is missing ids after reconstruction.\n"
-            , "Missing ids: ", show missing, "\n"
-            , "Expected ids: ", show (Set.toList expectedIds), "\n"
-            , "Observed ids: ", show (Set.toList observedIds)
-            ]
-        in QC.counterexample msg $ QC.property (Set.null (expectedIds Set.\\ observedIds))
-
--- | A dangling anchor refers to an anchor node that does not exist in the trunk.
--- fromReifiedBlockTree should reject forks with dangling anchors.
-prop_fromReifiedBlockTree_rejects_dangling_anchor
-  :: forall blk. (HasHeader blk, IssueTestBlock blk, Show blk)
-  => BlockTree blk -> QC.Property
-prop_fromReifiedBlockTree_rejects_dangling_anchor blockTree = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reified, _) = toReifiedBlockTree blockTree
-    mMutated = mutateDanglingAnchor reified
-  pure $ case mMutated of
-      Nothing -> QC.property True
-      Just mutated ->
-        let
-          msgSuccess = mconcat
-            [ "Expected fromReifiedBlockTree to reject dangling branch anchor, but it succeeded.\n"
-            , "Original reified tree: ", show reified, "\n"
-            , "Mutated reified tree: ", show mutated
-            ]
-        in case fromReifiedBlockTree ctx mutated :: Either String (BlockTree blk, KnownBlocks blk) of
-            Left _  -> QC.property True
-            Right _ -> QC.counterexample msgSuccess False
-
--- | Reified point schedules should only contain points that are present
--- in the block tree.
-prop_fromReifiedPointSchedule_rejects_unknown_point
-  :: forall blk. (HasHeader blk, IssueTestBlock blk, Show blk)
-  => BlockTree blk -> Schedule.PointSchedule blk -> QC.Property
-prop_fromReifiedPointSchedule_rejects_unknown_point blockTree pointSchedule = QC.ioProperty $ do
-  ctx <- getTestBlockContext $ Proxy @blk
-  let
-    (reifiedTree, knownForks) = toReifiedBlockTree blockTree
-    reifiedSchedule = toReifiedPointSchedule knownForks pointSchedule
-    hasSchedulePoints = not (null (toList reifiedSchedule))
-    cannotConvertTreeMsg err = mconcat
-      [ "Unable to decode reified block tree for point schedule test:\n"
-      , "ReifiedBlockTree: ", show reifiedTree, "\n"
-      , "Error: ", err
-      ]
-    fromReifiedTree :: Either String (BlockTree blk, KnownBlocks blk)
-    fromReifiedTree = fromReifiedBlockTree ctx reifiedTree
-  pure $ case fromReifiedTree of
-      Left err -> QC.counterexample (cannotConvertTreeMsg err) False
-      Right (_, knownBlocks) ->
-        let
-          badPoint = freshBlockId knownBlocks
-          mutatedSchedule = fmap (const badPoint) reifiedSchedule
-          msgSuccess = mconcat
-            [ "Expected fromReifiedPointSchedule to fail on unknown block ids, but it succeeded.\n"
-            , "Bad block id used: ", show badPoint, "\n"
-            , "Mutated schedule: ", show mutatedSchedule
-            ]
-        in hasSchedulePoints QC.==>
-            case fromReifiedPointSchedule knownBlocks mutatedSchedule of
-              Left _  -> QC.property True
-              Right _ -> QC.counterexample msgSuccess False
-
-parseReifiedTestCaseValue :: Aeson.Value -> Either String (ReifiedTestCase () BlockRep)
-parseReifiedTestCaseValue = Aeson.parseEither deserializeReifiedTestCase
-
--- | Invent a block id that is not present in the given KnownBlocks map.
-freshBlockId :: KnownBlocks blk -> BlockId
-freshBlockId knownBlocks =
-  let
-    ids = Set.fromList (M.keys (unKnownBlocks knownBlocks))
-    maxSlotNo = maximum (SlotNo 0 : fmap bidSlotNo (Set.toList ids))
-    maxBlockNo = maximum (BlockNo 0 : fmap bidBlockNo (Set.toList ids))
-    maxForkNo = maximum (ForkNo 0 : fmap bidForkNo (Set.toList ids))
-    SlotNo s = maxSlotNo
-    BlockNo b = maxBlockNo
-    ForkNo f = maxForkNo
-    candidate = BlockId (SlotNo (s + 1)) (BlockNo (b + 1)) (ForkNo (f + 1))
-  in if Set.member candidate ids
-      then BlockId (SlotNo (s + 2)) (BlockNo (b + 2)) (ForkNo (f + 2))
-      else candidate
-
--- | Mutate one branch anchor to refer to a slot and block number that are not
--- present in the tree.
-mutateDanglingAnchor
-  :: ReifiedBlockTree BlockRep
-  -> Maybe (ReifiedBlockTree BlockRep)
-mutateDanglingAnchor reified@ReifiedBlockTree{rbtBranches} =
-  let hasAnchor = isJust . forkAnchor
-  -- Find the first branch with an anchor and mutate it.
-  in case break hasAnchor rbtBranches of
-    (_, []) -> Nothing
-    (prefix, branch:suffix) ->
-      case forkAnchor branch of
-        Nothing -> Nothing
-        Just (slotNo, rep) ->
-          let
-            SlotNo s = slotNo
-            BlockNo n = brBlockNo rep
-            badSlotNo = SlotNo (s + 1000000)
-            badRep = rep { brBlockNo = BlockNo (n + 1000000) }
-            mutatedBranch = branch { forkAnchor = Just (badSlotNo, badRep) }
-          in Just reified { rbtBranches = prefix ++ (mutatedBranch : suffix) }
-
--- | Compute the set of block identifiers (slot and block number) for a fork.
-forkBlockIds :: AnchoredFork BlockRep -> [BlockId]
-forkBlockIds AnchoredFork{forkAnchor, forkBlocks, forkNumber} =
-  let
-    initialSlotNo = maybe (SlotNo 0) fst forkAnchor
-    step (currentSlotNo, acc) BlockRep{brSlotGap, brBlockNo} =
-      let nextSlotNo = currentSlotNo + fromIntegral brSlotGap
-      in (nextSlotNo, BlockId nextSlotNo brBlockNo forkNumber : acc)
-  in reverse $ snd $ foldl' step (initialSlotNo, []) forkBlocks
+parseReifiedTestCaseValue
+  :: (Aeson.FromJSON key) => Aeson.Value -> Either String (ReifiedTestCase key)
+parseReifiedTestCaseValue = Aeson.parseEither Aeson.parseJSON


### PR DESCRIPTION
https://github.com/tweag/ouroboros-consensus-testing/pull/31 added a test case type meant for serializing consensus test cases; this is the data to be generated by the test case generator and consumed by the test case viewer and runner.

As originally implemented that type included a representation of the test block tree and point schedule. Nevertheless it was incomplete as a representation of the full consensus test, which includes several other parameters as well as some non-representable function data. The problem is that generating a well-formed genesis test is super nontrivial and small changes in the configuration can have large effects on the test. By far the most reliable way to store a representation of a test case that will deterministically expand to a genesis test is to store the information QuickCheck uses to construct the test case: the seed for running `Gen` and an index into the shrink tree.

Conformance tests have a canonical generator and shrinker which we can use to recreate test cases instead of trying to faithfully reconstruct block trees and point schedules.

This patch deletes all the code and tests around serializing and deserializing block trees, which was extremely fiddly anyway.

This patch also generalizes the tests to use real test suite keys rather than dummy unit keys.

```
cabal test ouroboros-consensus-diffusion:consensus-test  --test-options='-p "/JSON Serialization/"'
```

Fixes https://github.com/tweag/cardano-conformance-testing-of-consensus/issues/107